### PR TITLE
feat: add new BroadcastTo and DynamicUpdateSlice operations with erro…

### DIFF
--- a/assets/descriptors/BroadcastFunctions/broadcast_to.yaml
+++ b/assets/descriptors/BroadcastFunctions/broadcast_to.yaml
@@ -37,3 +37,173 @@ hint:
   call_style: per_tensor
 input_shape: [2, 1, 3]
 output_shape: [2, 4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_identity_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape: [2, 3]
+output_shape: [2, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_last_dim_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape: [2, 1]
+output_shape: [2, 4]
+---
+operator: BroadcastTo
+name: broadcast_to_identity_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape: [2, 3]
+output_shape: [2, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_last_dim_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape: [2, 1]
+output_shape: [2, 4]
+---
+operator: BroadcastTo
+name: broadcast_to_null_input_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: input
+input_shape: [1, 3]
+output_shape: [4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_null_params_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: params
+input_shape: [1, 3]
+output_shape: [4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_null_output_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: output
+input_shape: [1, 3]
+output_shape: [4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_rank0_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 0
+input_shape: [1]
+output_shape: [1]
+---
+operator: BroadcastTo
+name: broadcast_to_rank9_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 9
+input_shape: [1]
+output_shape: [1]
+---
+operator: BroadcastTo
+name: broadcast_to_null_input_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: input
+input_shape: [1, 3]
+output_shape: [4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_null_params_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: params
+input_shape: [1, 3]
+output_shape: [4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_null_output_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: output
+input_shape: [1, 3]
+output_shape: [4, 3]
+---
+operator: BroadcastTo
+name: broadcast_to_rank0_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 0
+input_shape: [1]
+output_shape: [1]
+---
+operator: BroadcastTo
+name: broadcast_to_rank9_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 9
+input_shape: [1]
+output_shape: [1]

--- a/assets/descriptors/DynamicUpdateSliceFunctions/dynamic_update_slice.yaml
+++ b/assets/descriptors/DynamicUpdateSliceFunctions/dynamic_update_slice.yaml
@@ -41,3 +41,221 @@ hint:
 operand_shape: [2, 4, 6]
 update_shape: [1, 2, 3]
 start_indices: [0, 1, 2]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_clamped_start_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [-1, 99]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_clamped_start_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [-1, 99]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_operand_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: operand
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_update_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: update
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_start_indices_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: start_indices
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_params_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: params
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_output_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: output
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_rank0_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 0
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_rank9_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 9
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_operand_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: operand
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_update_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: update
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_start_indices_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: start_indices
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_params_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: params
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_null_output_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    arg_error_case: output
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_rank0_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 0
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]
+---
+operator: DynamicUpdateSlice
+name: dynamic_update_slice_rank9_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+expected_status: ARM_CMSIS_NN_ARG_ERROR
+hint:
+  call_style: per_tensor
+  extras:
+    params_rank: 9
+operand_shape: [4, 5]
+update_shape: [2, 3]
+start_indices: [1, 1]

--- a/assets/templates/BroadcastFunctions/broadcast_to/broadcast_to.c.j2
+++ b/assets/templates/BroadcastFunctions/broadcast_to/broadcast_to.c.j2
@@ -8,12 +8,17 @@ static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 int32_t {{ prefix }}_{{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
-        {{ name }}_input,
-        &{{ name }}_params,
-        {{ name }}_output
+        {{ input_arg | default(name ~ "_input") }},
+        {{ params_arg | default("&" ~ name ~ "_params") }},
+        {{ output_arg | default(name ~ "_output") }}
     );
-    HELIA_VALIDATE_STATUS("BroadcastTo", status);
+    HELIA_VALIDATE_EXPECTED_STATUS(
+        "BroadcastTo",
+        status,
+        {{ expected_status | default("ARM_CMSIS_NN_SUCCESS") }}
+    );
 
+{% if expected_status | default("ARM_CMSIS_NN_SUCCESS") == "ARM_CMSIS_NN_SUCCESS" %}
     int failures = 0;
     HELIA_VALIDATE_OUTPUTS(
         {{ validation_mode_token | default("TOLERANT_INT") }},
@@ -27,6 +32,9 @@ int32_t {{ prefix }}_{{ name }}_test_case_run(void)
         failures
     );
     HELIA_VALIDATE_RETURN_FAILURES(failures);
+{% else %}
+    HELIA_VALIDATE_RETURN_FAILURES(0);
+{% endif %}
 }
 
 {% include "common/standalone/main.j2" %}

--- a/assets/templates/DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.c.j2
+++ b/assets/templates/DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.c.j2
@@ -8,14 +8,19 @@ static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 int32_t {{ prefix }}_{{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
-        {{ name }}_operand,
-        {{ name }}_update,
-        {{ name }}_start_indices,
-        &{{ name }}_params,
-        {{ name }}_output
+        {{ operand_arg | default(name ~ "_operand") }},
+        {{ update_arg | default(name ~ "_update") }},
+        {{ start_indices_arg | default(name ~ "_start_indices") }},
+        {{ params_arg | default("&" ~ name ~ "_params") }},
+        {{ output_arg | default(name ~ "_output") }}
     );
-    HELIA_VALIDATE_STATUS("DynamicUpdateSlice", status);
+    HELIA_VALIDATE_EXPECTED_STATUS(
+        "DynamicUpdateSlice",
+        status,
+        {{ expected_status | default("ARM_CMSIS_NN_SUCCESS") }}
+    );
 
+{% if expected_status | default("ARM_CMSIS_NN_SUCCESS") == "ARM_CMSIS_NN_SUCCESS" %}
     int failures = 0;
     HELIA_VALIDATE_OUTPUTS(
         {{ validation_mode_token | default("TOLERANT_INT") }},
@@ -29,6 +34,9 @@ int32_t {{ prefix }}_{{ name }}_test_case_run(void)
         failures
     );
     HELIA_VALIDATE_RETURN_FAILURES(failures);
+{% else %}
+    HELIA_VALIDATE_RETURN_FAILURES(0);
+{% endif %}
 }
 
 {% include "common/standalone/main.j2" %}

--- a/helia_core_tester/generation/ops/BroadcastFunctions/broadcast_to.py
+++ b/helia_core_tester/generation/ops/BroadcastFunctions/broadcast_to.py
@@ -9,13 +9,46 @@ from helia_core_tester.generation.ops._shared.base import OperationBase
 class OpBroadcastTo(OperationBase):
     """BroadcastTo operation."""
 
+    _SUCCESS = "ARM_CMSIS_NN_SUCCESS"
+    _ARG_ERROR = "ARM_CMSIS_NN_ARG_ERROR"
+    _ARG_ERROR_CASES = {"input", "params", "output"}
+
     def needs_keras_model(self) -> bool:
         return False
+
+    def allow_no_tflite(self) -> bool:
+        return self._expected_status() != self._SUCCESS
 
     def build_keras_model(self):
         raise NotImplementedError("BroadcastTo uses LiteRT-only model generation.")
 
+    def _expected_status(self) -> str:
+        expected_status = str(self.desc.get("expected_status", self._SUCCESS))
+        if expected_status not in {self._SUCCESS, self._ARG_ERROR}:
+            raise ValueError(f"Unsupported BroadcastTo expected_status: {expected_status}")
+        return expected_status
+
+    def _extras(self) -> dict:
+        hint = self.desc.get("hint", {})
+        extras = hint.get("extras", {}) if isinstance(hint, dict) else {}
+        return extras if isinstance(extras, dict) else {}
+
+    def _arg_error_case(self) -> str | None:
+        case = self._extras().get("arg_error_case")
+        if case is None:
+            return None
+        case = str(case)
+        if case not in self._ARG_ERROR_CASES:
+            raise ValueError(f"Unsupported BroadcastTo arg_error_case: {case}")
+        return case
+
+    def _params_rank(self, default_rank: int) -> int:
+        return int(self._extras().get("params_rank", default_rank))
+
     def convert_to_tflite(self, model, out_path: str, rep_seed: int) -> None:
+        if self._expected_status() != self._SUCCESS:
+            raise RuntimeError("BroadcastTo expected error; skip LiteRT generation.")
+
         from helia_core_tester.generation.utils.litert_builder import (
             build_shape_transform_op, TensorSpec,
         )
@@ -57,45 +90,51 @@ class OpBroadcastTo(OperationBase):
         ki = self._select_kernel()
         input_shape = list(self.desc['input_shape'])
         output_shape = list(self.desc['output_shape'])
-        rank = len(output_shape)
+        data_rank = len(output_shape)
+        expected_status = self._expected_status()
+        params_rank = self._params_rank(data_rank)
+        arg_error_case = self._arg_error_case()
 
         rng = self._seeded_rng()
         np_dtype = np.int16 if ki['np_dtype'] == 'int16' else np.int8
         input_data = rng.integers(ki['qmin'], ki['qmax'] + 1, size=input_shape, dtype=np_dtype)
 
-        # Use TFLite TILE op (INT32) as interpreter proxy for BROADCAST_TO
-        # BROADCAST_TO is not registered in this runtime; TILE with multiples achieves same result
-        from ai_edge_litert.interpreter import Interpreter
-        from helia_core_tester.generation.utils.litert_builder import LiteRtSingleOpBuilder, TensorSpec
-        import ai_edge_litert.schema_py_generated as litert
+        if expected_status == self._SUCCESS:
+            # Use TFLite TILE op (INT32) as interpreter proxy for BROADCAST_TO.
+            # BROADCAST_TO is not registered in this runtime; TILE with multiples achieves the same result.
+            from ai_edge_litert.interpreter import Interpreter
+            from helia_core_tester.generation.utils.litert_builder import LiteRtSingleOpBuilder, TensorSpec
+            import ai_edge_litert.schema_py_generated as litert
 
-        multiples = [output_shape[i] // input_shape[i] for i in range(rank)]
-        builder = LiteRtSingleOpBuilder(op_name="TILE")
-        inp_idx = builder.add_tensor(TensorSpec(
-            name="input", shape=tuple(input_shape), tensor_type=litert.TensorType.INT32, is_input=True,
-        ))
-        mult_idx = builder.add_tensor(TensorSpec(
-            name="multiples", shape=(rank,), tensor_type=litert.TensorType.INT32,
-            is_input=False, data=np.array(multiples, dtype=np.int32),
-        ))
-        out_idx = builder.add_tensor(TensorSpec(
-            name="output", shape=tuple(output_shape), tensor_type=litert.TensorType.INT32, is_output=True,
-        ))
-        builder.add_operator("TILE", inputs=[inp_idx, mult_idx], outputs=[out_idx],
-            options=None, options_type=litert.BuiltinOptions.NONE)
-        interp = Interpreter(model_content=bytes(builder.build()))
-        interp.allocate_tensors()
-        inp_details = interp.get_input_details()
-        out_details = interp.get_output_details()
-        interp.set_tensor(inp_details[0]["index"], input_data.astype(np.int32))
-        interp.invoke()
-        output_data = interp.get_tensor(out_details[0]["index"]).astype(np_dtype)
+            multiples = [output_shape[i] // input_shape[i] for i in range(data_rank)]
+            builder = LiteRtSingleOpBuilder(op_name="TILE")
+            inp_idx = builder.add_tensor(TensorSpec(
+                name="input", shape=tuple(input_shape), tensor_type=litert.TensorType.INT32, is_input=True,
+            ))
+            mult_idx = builder.add_tensor(TensorSpec(
+                name="multiples", shape=(data_rank,), tensor_type=litert.TensorType.INT32,
+                is_input=False, data=np.array(multiples, dtype=np.int32),
+            ))
+            out_idx = builder.add_tensor(TensorSpec(
+                name="output", shape=tuple(output_shape), tensor_type=litert.TensorType.INT32, is_output=True,
+            ))
+            builder.add_operator("TILE", inputs=[inp_idx, mult_idx], outputs=[out_idx],
+                options=None, options_type=litert.BuiltinOptions.NONE)
+            interp = Interpreter(model_content=bytes(builder.build()))
+            interp.allocate_tensors()
+            inp_details = interp.get_input_details()
+            out_details = interp.get_output_details()
+            interp.set_tensor(inp_details[0]["index"], input_data.astype(np.int32))
+            interp.invoke()
+            output_data = interp.get_tensor(out_details[0]["index"]).astype(np_dtype)
+        else:
+            output_data = np.zeros(output_shape, dtype=np_dtype)
 
         builder = TemplateContextBuilder()
         context = {
             'name': name,
             'prefix': name,
-            'rank': rank,
+            'rank': params_rank,
             'input_shape': input_shape,
             'output_shape': output_shape,
             'input_size': int(np.prod(input_shape)),
@@ -104,6 +143,10 @@ class OpBroadcastTo(OperationBase):
             'expected_output_array': builder.format_array_as_c_literal(output_data),
             'c_type': ki['c_type'],
             'kernel_fn': ki['kernel_fn'],
+            'expected_status': expected_status,
+            'input_arg': 'NULL' if arg_error_case == 'input' else f'{name}_input',
+            'params_arg': 'NULL' if arg_error_case == 'params' else f'&{name}_params',
+            'output_arg': 'NULL' if arg_error_case == 'output' else f'{name}_output',
         }
 
         includes_dir = output_dir / "includes"

--- a/helia_core_tester/generation/ops/DynamicUpdateSliceFunctions/dynamic_update_slice.py
+++ b/helia_core_tester/generation/ops/DynamicUpdateSliceFunctions/dynamic_update_slice.py
@@ -9,13 +9,46 @@ from helia_core_tester.generation.ops._shared.base import OperationBase
 class OpDynamicUpdateSlice(OperationBase):
     """DynamicUpdateSlice operation."""
 
+    _SUCCESS = "ARM_CMSIS_NN_SUCCESS"
+    _ARG_ERROR = "ARM_CMSIS_NN_ARG_ERROR"
+    _ARG_ERROR_CASES = {"operand", "update", "start_indices", "params", "output"}
+
     def needs_keras_model(self) -> bool:
         return False
+
+    def allow_no_tflite(self) -> bool:
+        return self._expected_status() != self._SUCCESS
 
     def build_keras_model(self):
         raise NotImplementedError("DynamicUpdateSlice uses LiteRT-only model generation.")
 
+    def _expected_status(self) -> str:
+        expected_status = str(self.desc.get("expected_status", self._SUCCESS))
+        if expected_status not in {self._SUCCESS, self._ARG_ERROR}:
+            raise ValueError(f"Unsupported DynamicUpdateSlice expected_status: {expected_status}")
+        return expected_status
+
+    def _extras(self) -> dict:
+        hint = self.desc.get("hint", {})
+        extras = hint.get("extras", {}) if isinstance(hint, dict) else {}
+        return extras if isinstance(extras, dict) else {}
+
+    def _arg_error_case(self) -> str | None:
+        case = self._extras().get("arg_error_case")
+        if case is None:
+            return None
+        case = str(case)
+        if case not in self._ARG_ERROR_CASES:
+            raise ValueError(f"Unsupported DynamicUpdateSlice arg_error_case: {case}")
+        return case
+
+    def _params_rank(self, default_rank: int) -> int:
+        return int(self._extras().get("params_rank", default_rank))
+
     def convert_to_tflite(self, model, out_path: str, rep_seed: int) -> None:
+        if self._expected_status() != self._SUCCESS:
+            raise RuntimeError("DynamicUpdateSlice expected error; skip LiteRT generation.")
+
         from helia_core_tester.generation.utils.litert_builder import (
             LiteRtSingleOpBuilder, TensorSpec, _default_quant,
         )
@@ -63,28 +96,40 @@ class OpDynamicUpdateSlice(OperationBase):
         operand_shape = list(self.desc["operand_shape"])
         update_shape = list(self.desc["update_shape"])
         start_indices = list(self.desc["start_indices"])
-        rank = len(operand_shape)
+        data_rank = len(operand_shape)
+        expected_status = self._expected_status()
+        params_rank = self._params_rank(data_rank)
+        arg_error_case = self._arg_error_case()
 
         rng = self._seeded_rng()
         np_dtype = np.int16 if ki["np_dtype"] == "int16" else np.int8
         operand_data = rng.integers(ki["qmin"], ki["qmax"] + 1, size=operand_shape, dtype=np_dtype)
         update_data = rng.integers(ki["qmin"], ki["qmax"] + 1, size=update_shape, dtype=np_dtype)
 
-        # Use TFLite interpreter for reference output (fallback to numpy if unsupported)
-        tflite_path = str(output_dir / f"{name}.tflite")
-        try:
-            interpreter = self.load_litert_interpreter(tflite_path)
-            input_details = interpreter.get_input_details()
-            output_details = interpreter.get_output_details()
-            interpreter.set_tensor(input_details[0]["index"], operand_data)
-            interpreter.set_tensor(input_details[1]["index"], update_data)
-            interpreter.set_tensor(input_details[2]["index"], np.array(start_indices, dtype=np.int32))
-            interpreter.invoke()
-            output_data = np.array(interpreter.get_tensor(output_details[0]["index"]))
-        except (ValueError, RuntimeError):
+        if expected_status == self._SUCCESS:
+            # Use TFLite interpreter for reference output (fallback to numpy if unsupported).
+            tflite_path = str(output_dir / f"{name}.tflite")
+            try:
+                interpreter = self.load_litert_interpreter(tflite_path)
+                input_details = interpreter.get_input_details()
+                output_details = interpreter.get_output_details()
+                interpreter.set_tensor(input_details[0]["index"], operand_data)
+                interpreter.set_tensor(input_details[1]["index"], update_data)
+                interpreter.set_tensor(input_details[2]["index"], np.array(start_indices, dtype=np.int32))
+                interpreter.invoke()
+                output_data = np.array(interpreter.get_tensor(output_details[0]["index"]))
+            except (ValueError, RuntimeError):
+                clamped_starts = [
+                    min(max(0, start_indices[i]), operand_shape[i] - update_shape[i])
+                    for i in range(data_rank)
+                ]
+                output_data = operand_data.copy()
+                slices = tuple(slice(s, s + u) for s, u in zip(clamped_starts, update_shape))
+                output_data[slices] = update_data
+        else:
             clamped_starts = [
                 min(max(0, start_indices[i]), operand_shape[i] - update_shape[i])
-                for i in range(rank)
+                for i in range(data_rank)
             ]
             output_data = operand_data.copy()
             slices = tuple(slice(s, s + u) for s, u in zip(clamped_starts, update_shape))
@@ -101,7 +146,7 @@ class OpDynamicUpdateSlice(OperationBase):
         context = {
             "name": name,
             "prefix": name,
-            "rank": rank,
+            "rank": params_rank,
             "operand_shape": operand_shape,
             "update_shape": update_shape,
             "start_indices": start_indices,
@@ -114,6 +159,12 @@ class OpDynamicUpdateSlice(OperationBase):
             "expected_output_array": builder.format_array_as_c_literal(output_data),
             "c_type": ki["c_type"],
             "kernel_fn": ki["kernel_fn"],
+            "expected_status": expected_status,
+            "operand_arg": "NULL" if arg_error_case == "operand" else f"{name}_operand",
+            "update_arg": "NULL" if arg_error_case == "update" else f"{name}_update",
+            "start_indices_arg": "NULL" if arg_error_case == "start_indices" else f"{name}_start_indices",
+            "params_arg": "NULL" if arg_error_case == "params" else f"&{name}_params",
+            "output_arg": "NULL" if arg_error_case == "output" else f"{name}_output",
         }
 
         includes_dir = output_dir / "includes"

--- a/helia_core_tester/tests/test_template_standalone_contract.py
+++ b/helia_core_tester/tests/test_template_standalone_contract.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import jinja2
 
+from helia_core_tester.generation.ops.BroadcastFunctions.broadcast_to import OpBroadcastTo
+from helia_core_tester.generation.ops.DynamicUpdateSliceFunctions.dynamic_update_slice import OpDynamicUpdateSlice
 from helia_core_tester.generation.utils.template_context import TemplateContextBuilder
 
 
@@ -238,6 +240,101 @@ def test_rsqrt_invalid_status_render_uses_expected_status_helper() -> None:
     assert "HELIA_VALIDATE_EXPECTED_STATUS(" in text
     assert "ARM_CMSIS_NN_ARG_ERROR" in text
     assert "{{ name }}_expected_output" not in text
+
+
+def test_broadcast_to_invalid_status_render_uses_expected_status_helper() -> None:
+    text = _render(
+        "BroadcastFunctions/broadcast_to/broadcast_to.c.j2",
+        {
+            "name": "broadcast_invalid_smoke",
+            "prefix": "broadcast",
+            "c_type": "int8_t",
+            "kernel_fn": "arm_broadcast_to_s8",
+            "output_size": 4,
+            "expected_status": "ARM_CMSIS_NN_ARG_ERROR",
+            "input_arg": "NULL",
+            "params_arg": "&broadcast_invalid_smoke_params",
+            "output_arg": "broadcast_invalid_smoke_output",
+        },
+    )
+
+    assert "HELIA_VALIDATE_EXPECTED_STATUS(" in text
+    assert "ARM_CMSIS_NN_ARG_ERROR" in text
+    assert "NULL," in text
+    assert "broadcast_invalid_smoke_expected_output" not in text
+
+
+def test_dynamic_update_slice_invalid_status_render_uses_expected_status_helper() -> None:
+    text = _render(
+        "DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.c.j2",
+        {
+            "name": "dynamic_update_slice_invalid_smoke",
+            "prefix": "dynamic_update_slice",
+            "c_type": "int8_t",
+            "kernel_fn": "arm_dynamic_update_slice_s8",
+            "operand_size": 20,
+            "expected_status": "ARM_CMSIS_NN_ARG_ERROR",
+            "operand_arg": "dynamic_update_slice_invalid_smoke_operand",
+            "update_arg": "dynamic_update_slice_invalid_smoke_update",
+            "start_indices_arg": "NULL",
+            "params_arg": "&dynamic_update_slice_invalid_smoke_params",
+            "output_arg": "dynamic_update_slice_invalid_smoke_output",
+        },
+    )
+
+    assert "HELIA_VALIDATE_EXPECTED_STATUS(" in text
+    assert "ARM_CMSIS_NN_ARG_ERROR" in text
+    assert "NULL," in text
+    assert "dynamic_update_slice_invalid_smoke_expected_output" not in text
+
+
+def test_broadcast_to_expected_error_generation_renders_rank_override(tmp_path: Path) -> None:
+    desc = {
+        "operator": "BroadcastTo",
+        "name": "broadcast_to_rank9_smoke",
+        "activation_dtype": "S8",
+        "weight_dtype": "S8",
+        "activation": "NONE",
+        "expected_status": "ARM_CMSIS_NN_ARG_ERROR",
+        "hint": {"call_style": "per_tensor", "extras": {"params_rank": 9}},
+        "input_shape": [1],
+        "output_shape": [1],
+    }
+    op = OpBroadcastTo(desc, seed=1)
+
+    assert op.allow_no_tflite()
+    op.generate_c_files(tmp_path)
+
+    header = (tmp_path / "includes" / "broadcast_to_rank9_smoke_broadcast_to.h").read_text()
+    source = (tmp_path / "broadcast_to_rank9_smoke_broadcast_to.c").read_text()
+    assert ".rank = 9" in header
+    assert "ARM_CMSIS_NN_ARG_ERROR" in source
+    assert "HELIA_VALIDATE_RETURN_FAILURES(0)" in source
+
+
+def test_dynamic_update_slice_expected_error_generation_renders_rank_override(tmp_path: Path) -> None:
+    desc = {
+        "operator": "DynamicUpdateSlice",
+        "name": "dynamic_update_slice_rank0_smoke",
+        "activation_dtype": "S8",
+        "weight_dtype": "S8",
+        "activation": "NONE",
+        "expected_status": "ARM_CMSIS_NN_ARG_ERROR",
+        "hint": {"call_style": "per_tensor", "extras": {"params_rank": 0}},
+        "operand_shape": [4, 5],
+        "update_shape": [2, 3],
+        "start_indices": [1, 1],
+    }
+    op = OpDynamicUpdateSlice(desc, seed=1)
+
+    assert op.allow_no_tflite()
+    op.generate_c_files(tmp_path)
+
+    header = (tmp_path / "includes" / "dynamic_update_slice_rank0_smoke_dynamic_update_slice.h").read_text()
+    source = (tmp_path / "dynamic_update_slice_rank0_smoke_dynamic_update_slice.c").read_text()
+    assert ".rank = 0" in header
+    assert "ARM_CMSIS_NN_ARG_ERROR" in source
+    assert "HELIA_VALIDATE_RETURN_FAILURES(0)" in source
 
 
 def test_lstm_and_svdf_keep_specialized_shared_validation_contracts() -> None:


### PR DESCRIPTION
This pull request adds comprehensive error case coverage and improved error handling to the test generation for the `BroadcastTo` and `DynamicUpdateSlice` operations. It introduces new test descriptors for various invalid argument scenarios, updates the Python test generators to support expected failures, and modifies the C test templates to validate expected error statuses. These changes help ensure robust validation of argument checking in the kernel implementations.

**Test Descriptor Additions:**

* Added new test cases to `broadcast_to.yaml` and `dynamic_update_slice.yaml` for `BroadcastTo` and `DynamicUpdateSlice` covering identity, last-dimension, and multiple error scenarios (such as null input/params/output, and invalid parameter ranks), with expected error statuses specified. [[1]](diffhunk://#diff-7f56476839f602d8aba5c43d510a5c0e0053ec05b52ae66eab42124e591f1d8fR40-R209) [[2]](diffhunk://#diff-5cbee371c605d6308d8fbf9d5be5fc637f1dcb08a694d12101d427e66878d13cR44-R261)

**Python Test Generator Enhancements:**

* Updated `broadcast_to.py` and `dynamic_update_slice.py` to:
  - Parse and handle new `expected_status` and `arg_error_case` fields from descriptors.
  - Generate argument error test cases by passing `NULL` for specified arguments and skipping TFLite model generation for expected failures.
  - Dynamically set the rank and argument values in generated C code based on error case. [[1]](diffhunk://#diff-daf4c487c3130d2344e0d0e5367de6a32927e9ea2bcc9ee064188fa746f4a6b4R12-R51) [[2]](diffhunk://#diff-daf4c487c3130d2344e0d0e5367de6a32927e9ea2bcc9ee064188fa746f4a6b4L60-R115) [[3]](diffhunk://#diff-daf4c487c3130d2344e0d0e5367de6a32927e9ea2bcc9ee064188fa746f4a6b4R130-R137) [[4]](diffhunk://#diff-daf4c487c3130d2344e0d0e5367de6a32927e9ea2bcc9ee064188fa746f4a6b4R146-R149) [[5]](diffhunk://#diff-afeae9ada5d596cdfcd0d839c59aa3f8f3f995fd7ecb04a0a7d1ffc013d3de21R12-R51) [[6]](diffhunk://#diff-afeae9ada5d596cdfcd0d839c59aa3f8f3f995fd7ecb04a0a7d1ffc013d3de21L66-R110) [[7]](diffhunk://#diff-afeae9ada5d596cdfcd0d839c59aa3f8f3f995fd7ecb04a0a7d1ffc013d3de21L87-R132) [[8]](diffhunk://#diff-afeae9ada5d596cdfcd0d839c59aa3f8f3f995fd7ecb04a0a7d1ffc013d3de21L104-R149) [[9]](diffhunk://#diff-afeae9ada5d596cdfcd0d839c59aa3f8f3f995fd7ecb04a0a7d1ffc013d3de21R162-R167)

**C Test Template Updates:**

* Modified the C test templates for both ops to:
  - Accept argument overrides (e.g., `NULL` for error cases).
  - Validate the returned status against the expected status using `HELIA_VALIDATE_EXPECTED_STATUS`.
  - Only run output validation when the expected status is success; otherwise, immediately return success for error cases. [[1]](diffhunk://#diff-db4c1c344ddc1cbb93cfd8c0c76059583be1172ddbe22cba78312339fe42db22L11-R21) [[2]](diffhunk://#diff-db4c1c344ddc1cbb93cfd8c0c76059583be1172ddbe22cba78312339fe42db22R35-R37) [[3]](diffhunk://#diff-2dfeb985cb6f62723cf3339561968ad173de00f5852005849d3238e844b87110L11-R23) [[4]](diffhunk://#diff-2dfeb985cb6f62723cf3339561968ad173de00f5852005849d3238e844b87110R37-R39)

These changes collectively ensure that both valid and invalid argument scenarios are thoroughly tested, and that error handling is explicitly validated for these operations.