### PR TITLE
fix: copillot code review fixes

### DIFF
--- a/assets/descriptors/ActivationFunctions/prelu.yaml
+++ b/assets/descriptors/ActivationFunctions/prelu.yaml
@@ -133,6 +133,8 @@ alpha_shape: [1]
 alpha: 0.2
 ---
 # Disabled due LiteRT PRELU prepare failure (HaveSameShapes input/output) in CI.
+# Restored under assets/descriptors/ActivationFunctions/prelu_scalar.yaml using the
+# LiteRT-independent PReLUScalar direct-kernel operator (see COR-002 / TEST-005).
 # operator: PReLU
 # name: prelu_scalar_input_all_positive_s8
 # activation_dtype: S8
@@ -147,6 +149,8 @@ alpha: 0.2
 # alpha_shape: [1, 1, 1, 4]
 ---
 # Disabled due LiteRT PRELU prepare failure (HaveSameShapes input/output) in CI.
+# Restored under assets/descriptors/ActivationFunctions/prelu_scalar.yaml using the
+# LiteRT-independent PReLUScalar direct-kernel operator (see COR-002 / TEST-005).
 # operator: PReLU
 # name: prelu_scalar_input_all_negative_s8
 # activation_dtype: S8
@@ -161,6 +165,8 @@ alpha: 0.2
 # alpha_shape: [1, 1, 1, 4]
 ---
 # Disabled due LiteRT PRELU prepare failure (HaveSameShapes input/output) in CI.
+# Restored under assets/descriptors/ActivationFunctions/prelu_scalar.yaml using the
+# LiteRT-independent PReLUScalar direct-kernel operator (see COR-002 / TEST-005).
 # operator: PReLU
 # name: prelu_scalar_input_zero_boundary_s8
 # activation_dtype: S8
@@ -175,6 +181,8 @@ alpha: 0.2
 # alpha_shape: [1, 1, 1, 4]
 ---
 # Disabled due LiteRT PRELU prepare failure (HaveSameShapes input/output) in CI.
+# Restored under assets/descriptors/ActivationFunctions/prelu_scalar.yaml using the
+# LiteRT-independent PReLUScalar direct-kernel operator (see COR-002 / TEST-005).
 # operator: PReLU
 # name: prelu_scalar_input_clamp_pressure_s8
 # activation_dtype: S8
@@ -189,6 +197,8 @@ alpha: 0.2
 # alpha_shape: [1, 1, 1, 4]
 ---
 # Disabled due LiteRT PRELU prepare failure (HaveSameShapes input/output) in CI.
+# Restored under assets/descriptors/ActivationFunctions/prelu_scalar.yaml using the
+# LiteRT-independent PReLUScalar direct-kernel operator (see COR-002 / TEST-005).
 # operator: PReLU
 # name: prelu_pixel_scalar_input_broadcast_c_s8
 # activation_dtype: S8
@@ -213,6 +223,7 @@ input_shape: [1, 2, 2, 3]
 alpha_shape: [1, 2, 2, 3]
 output_shape: [1, 2, 2, 2]
 alpha: 0.2
+expected_status: ARM_CMSIS_NN_ARG_ERROR
 ---
 operator: PReLU
 name: prelu_batch_row_nobcast_s8

--- a/assets/descriptors/ActivationFunctions/prelu_scalar.yaml
+++ b/assets/descriptors/ActivationFunctions/prelu_scalar.yaml
@@ -33,3 +33,28 @@ input_shape: [1, 1, 1, 1]
 alpha_shape: [1, 1, 1, 4]
 scalar_input_value: 0.0
 alpha_values: [0.05, 0.10, 0.15, 0.20]
+---
+operator: PReLUScalar
+name: prelu_scalar_input_clamp_pressure_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape: [1, 1, 1, 1]
+alpha_shape: [1, 1, 1, 4]
+scalar_input_value: -1.0
+alpha_values: [0.25, 0.5, 0.75, 1.0]
+---
+operator: PReLUScalar
+name: prelu_pixel_scalar_input_broadcast_c_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+  extras:
+    input_values: [0.8, -0.8]
+    alpha_values: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+input_shape: [1, 1, 2, 1]
+alpha_shape: [1, 1, 2, 3]

--- a/assets/templates/ActivationFunctions/prelu/prelu.c.j2
+++ b/assets/templates/ActivationFunctions/prelu/prelu.c.j2
@@ -32,8 +32,13 @@ int32_t {{ prefix }}_{{ name }}_run(
 int32_t {{ prefix }}_{{ name }}_test_case_run(void)
 {
     int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
-    HELIA_VALIDATE_STATUS("{{ validation_label | default("PReLU") }}", status);
+    HELIA_VALIDATE_EXPECTED_STATUS(
+        "{{ validation_label | default("PReLU") }}",
+        status,
+        {{ expected_status | default("ARM_CMSIS_NN_SUCCESS") }}
+    );
 
+{% if expected_status | default("ARM_CMSIS_NN_SUCCESS") == "ARM_CMSIS_NN_SUCCESS" %}
     int failures = 0;
     HELIA_VALIDATE_OUTPUTS(
         {{ validation_mode_token | default("TOLERANT_INT") }},
@@ -47,6 +52,9 @@ int32_t {{ prefix }}_{{ name }}_test_case_run(void)
         failures
     );
     HELIA_VALIDATE_RETURN_FAILURES(failures);
+{% else %}
+    HELIA_VALIDATE_RETURN_FAILURES(0);
+{% endif %}
 }
 
 {% include "common/standalone/main.j2" %}

--- a/assets/templates/ActivationFunctions/prelu_scalar/prelu_scalar.c.j2
+++ b/assets/templates/ActivationFunctions/prelu_scalar/prelu_scalar.c.j2
@@ -2,7 +2,7 @@
 #include "arm_nnfunctions.h"
 {% include "common/standalone/runtime_common.j2" %}
 
-#define {{ name|upper }}_OUTPUT_SIZE {{ block_size }}
+#define {{ name|upper }}_OUTPUT_SIZE ({{ num_pixels | default(1) }} * {{ block_size }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
 int32_t {{ prefix }}_{{ name }}_run(
@@ -10,9 +10,11 @@ int32_t {{ prefix }}_{{ name }}_run(
     const {{ input_dtype }}* __restrict alpha,
     {{ output_dtype }}* __restrict output
 ) {
-    arm_cmsis_nn_status kernel_status = arm_prelu_scalar_s8(
-        scalar_input,
-        alpha,
+    arm_cmsis_nn_status kernel_status = ARM_CMSIS_NN_SUCCESS;
+{% for pixel in range(num_pixels | default(1)) %}
+    kernel_status = arm_prelu_scalar_s8(
+        scalar_input + {{ pixel }},
+        alpha + {{ pixel * block_size }},
         true,
         {{ input_offset }},
         {{ alpha_offset }},
@@ -21,10 +23,13 @@ int32_t {{ prefix }}_{{ name }}_run(
         {{ output_shift_identity }},
         {{ output_mult_alpha }},
         {{ output_shift_alpha }},
-        output,
+        output + {{ pixel * block_size }},
         {{ block_size }}
     );
-
+    if (kernel_status != ARM_CMSIS_NN_SUCCESS) {
+        return kernel_status;
+    }
+{% endfor %}
     return kernel_status;
 }
 

--- a/helia_core_tester/core/steps/build.py
+++ b/helia_core_tester/core/steps/build.py
@@ -129,14 +129,18 @@ class BuildStep(StepBase):
             error_msg = f"Failed to build for FVP (exit code {e.returncode})"
             self.logger.error(error_msg)
             
-            # Try to capture more error details
+            # Try to capture more error details. Reuse the same runtime
+            # environment as the real build invocation so this diagnostic
+            # rerun can actually reproduce (and report on) the original
+            # failure instead of running under a different environment.
             try:
                 result = subprocess.run(
                     cmd,
                     cwd=self.config.project_root,
                     capture_output=True,
                     text=True,
-                    check=False
+                    check=False,
+                    env=runtime_env.child_env,
                 )
                 if result.stdout:
                     self.logger.error(f"stdout: {result.stdout}")

--- a/helia_core_tester/core/steps/clean.py
+++ b/helia_core_tester/core/steps/clean.py
@@ -53,7 +53,11 @@ class CleanStep(StepBase):
                     continue
                 if self.config.verbosity >= 1:
                     self.logger.info(f"Removing: {path}")
-                shutil.rmtree(path, ignore_errors=True)
+                # Do not use ignore_errors=True: a failed removal (permissions,
+                # open file handles, read-only files) must surface as a step
+                # failure instead of being silently reported as cleaned, which
+                # would let later stages consume stale artifacts.
+                shutil.rmtree(path)
                 cleaned_items.append(str(path))
 
             message = (

--- a/helia_core_tester/generation/io/descriptors.py
+++ b/helia_core_tester/generation/io/descriptors.py
@@ -119,7 +119,7 @@ OPERATOR_EXTRA_REQUIRED_FIELDS = {'BroadcastTo': ('output_shape',),
  'Reshape': ('target_shape',),
  'NNActivationFloat': ('activation_type',),
  'NNActivationS16': ('activation_type',),
- 'PReLUScalar': ('alpha_shape', 'scalar_input_value'),
+ 'PReLUScalar': ('alpha_shape',),
  'Requantize': ('effective_scale_multiplier',
                 'effective_scale_shift',
                 'input_zeropoint',
@@ -174,6 +174,15 @@ def _validate_profile_requirements(
     for field in OPERATOR_EXTRA_REQUIRED_FIELDS.get(operator, ()):
         if field not in desc:
             raise ValueError(f"{operator}{suffix} requires {field}")
+
+    if operator == 'PReLUScalar':
+        has_scalar_field = 'scalar_input_value' in desc
+        has_extras_values = bool(desc.get('hint', {}).get('extras', {}).get('input_values'))
+        if not has_scalar_field and not has_extras_values:
+            raise ValueError(
+                f"{operator}{suffix} requires 'scalar_input_value' (single pixel) or "
+                "hint.extras.input_values (one value per pixel, multi-pixel)"
+            )
 
     for field, expected in OPERATOR_FIELD_CONSTRAINTS.get(operator, {}).items():
         if str(desc.get(field, "")).upper() != str(expected).upper():

--- a/helia_core_tester/generation/ops/ActivationFunctions/prelu.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/prelu.py
@@ -44,8 +44,51 @@ class OpPReLU(OperationBase):
     def build_keras_model(self):
         raise NotImplementedError("PReLU uses LiteRT-only model generation.")
 
+    def _expected_status(self) -> str:
+        return self.desc.get("expected_status", "ARM_CMSIS_NN_SUCCESS")
+
+    def _is_arg_error_case(self) -> bool:
+        return self._expected_status() != "ARM_CMSIS_NN_SUCCESS"
+
+    def _resolved_alpha_shape(self) -> tuple:
+        input_shape = tuple(self.desc["input_shape"])
+        alpha_shape = self.desc.get("alpha_shape")
+        if alpha_shape is not None:
+            return tuple(alpha_shape)
+        return input_shape[1:]
+
+    def _validate_broadcast_support(self, input_shape: tuple, alpha_shape: tuple) -> None:
+        """
+        Reject scalar-input + multi-element-alpha broadcasts at load/convert time.
+
+        LiteRT's PRELU op preparation cannot handle a scalar (single-element)
+        input broadcasting against a multi-element alpha (fails with
+        "HaveSameShapes input/output" during graph preparation). Rather than
+        letting that surface as an opaque LiteRT prepare failure, fail fast
+        with an actionable message pointing at the supported direct-kernel
+        path (operator: PReLUScalar) for this broadcast shape.
+        """
+        if int(np.prod(input_shape)) == 1 and int(np.prod(alpha_shape)) > 1:
+            raise ValueError(
+                "PReLU with a scalar (single-element) input and a multi-element alpha "
+                "broadcast is not supported via LiteRT (known PRELU prepare failure: "
+                "'HaveSameShapes input/output'). Use operator: PReLUScalar instead, which "
+                "implements this broadcast directly against arm_prelu_scalar_s8 without "
+                "requiring LiteRT model preparation."
+            )
+
+    def allow_no_tflite(self) -> bool:
+        return self._is_arg_error_case()
+
     def convert_to_tflite(self, model, out_path: str, rep_seed: int) -> None:
         """Generate LiteRT model for PReLU."""
+        if self._is_arg_error_case():
+            raise RuntimeError(
+                "PReLU expected-error test case; skip TFLite generation and exercise "
+                "the CMSIS kernel directly with the descriptor's (deliberately "
+                "mismatched) shapes."
+            )
+
         from helia_core_tester.generation.utils.litert_builder import build_prelu_op
 
         activation_dtype = self.desc.get("activation_dtype", "S8")
@@ -53,11 +96,8 @@ class OpPReLU(OperationBase):
             raise NotImplementedError(f"Unsupported PReLU dtype: {activation_dtype} (only S8 supported)")
 
         input_shape = tuple(self.desc["input_shape"])
-        alpha_shape = self.desc.get("alpha_shape")
-        if alpha_shape is not None:
-            alpha_shape = tuple(alpha_shape)
-        else:
-            alpha_shape = input_shape[1:]
+        alpha_shape = self._resolved_alpha_shape()
+        self._validate_broadcast_support(input_shape, alpha_shape)
 
         # Get alpha values from descriptor
         alpha_values = None
@@ -108,10 +148,89 @@ class OpPReLU(OperationBase):
         else:
             raise NotImplementedError(f"Unsupported PReLU dtype: {activation_dtype} (only S8 supported)")
     
+    def _generate_arg_error_c_files(self, output_dir: Path) -> None:
+        """
+        Generate a CMSIS-direct harness for a deliberately-mismatched-shape
+        PReLU test case, expecting arm_prelu_s8 to return ARM_CMSIS_NN_ARG_ERROR
+        (input_dims != output_dims is rejected up front by the kernel, before
+        any TFLite model is needed).
+        """
+        from helia_core_tester.generation.utils.template_context import TemplateContextBuilder
+        from helia_core_tester.generation.utils.tflite_utils import calculate_multiplier_shift
+
+        name = self.desc['name']
+        kernel_info = self._select_cmsis_prelu_kernel()
+
+        input_shape = tuple(self.desc['input_shape'])
+        alpha_shape = self._resolved_alpha_shape()
+        output_shape = tuple(self.desc.get('output_shape', input_shape))
+
+        builder = TemplateContextBuilder()
+        input_dims = builder.nhwc_to_cmsis_dims(input_shape)
+        alpha_dims = builder.nhwc_to_cmsis_dims(alpha_shape)
+        output_dims = builder.nhwc_to_cmsis_dims(output_shape)
+
+        mult_identity, shift_identity = calculate_multiplier_shift(1.0)
+        mult_alpha, shift_alpha = calculate_multiplier_shift(1.0)
+
+        rng = self._seeded_rng()
+        input_q = rng.integers(-128, 128, size=input_shape, dtype=np.int32).astype(np.int8)
+        alpha_q = rng.integers(-128, 128, size=alpha_shape, dtype=np.int32).astype(np.int8)
+
+        # Kernel is expected to reject before producing real output; a single
+        # placeholder element is sufficient (mirrors Transpose's ARG_ERROR path).
+        expected_output = np.zeros((1,), dtype=np.int8)
+
+        context = {
+            'name': name,
+            'prefix': name,
+            'input_dims': input_dims,
+            'alpha_dims': alpha_dims,
+            'output_dims': output_dims,
+            'input_offset': 0,
+            'alpha_offset': 0,
+            'output_offset': 0,
+            'output_mult_alpha': int(mult_alpha),
+            'output_shift_alpha': int(shift_alpha),
+            'output_mult_identity': int(mult_identity),
+            'output_shift_identity': int(shift_identity),
+            'input_data_array': builder.format_array_as_c_literal(input_q),
+            'alpha_array': builder.format_array_as_c_literal(alpha_q),
+            'expected_output_array': builder.format_array_as_c_literal(expected_output),
+            'input_dtype': kernel_info["input_c_type"],
+            'output_dtype': kernel_info["output_c_type"],
+            'kernel_fn': kernel_info["kernel_fn"],
+            'expected_status': self._expected_status(),
+        }
+
+        includes_api_dir = output_dir / "includes"
+        includes_api_dir.mkdir(parents=True, exist_ok=True)
+
+        h_content = self.render_template("ActivationFunctions/prelu/prelu.h.j2", context)
+        with open(includes_api_dir / f"{name}_prelu.h", 'w') as f:
+            f.write(h_content)
+
+        c_content = self.render_template("ActivationFunctions/prelu/prelu.c.j2", context)
+        with open(output_dir / f"{name}_prelu.c", 'w') as f:
+            f.write(c_content)
+
+        cmake_context = {
+            'name': name,
+            'operator': self.desc.get('operator', 'PReLU'),
+            'operator_name': 'prelu',
+        }
+        cmake_content = self.render_template("common/CMakeLists.txt.j2", cmake_context)
+        with open(output_dir / "CMakeLists.txt", 'w') as f:
+            f.write(cmake_content)
+
     def generate_c_files(self, output_dir: Path) -> None:
         """
         Generate C and H files from templates for PReLU operation.
         """
+        if self._is_arg_error_case():
+            self._generate_arg_error_c_files(output_dir)
+            return
+
         from helia_core_tester.generation.utils.template_context import TemplateContextBuilder
         from helia_core_tester.generation.utils.tflite_utils import calculate_multiplier_shift
         from helia_core_tester.generation.utils.litert_utils import (

--- a/helia_core_tester/generation/ops/ActivationFunctions/prelu_scalar.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/prelu_scalar.py
@@ -84,23 +84,49 @@ class OpPReLUScalar(OperationBase):
         name = self.desc["name"]
 
         input_shape = tuple(int(dim) for dim in self.desc.get("input_shape", [1, 1, 1, 1]))
-        if int(np.prod(input_shape)) != 1:
-            raise ValueError("PReLUScalar requires input_shape with exactly one scalar element.")
+        num_pixels = int(np.prod(input_shape))
+        if num_pixels <= 0:
+            raise ValueError("input_shape must contain positive dimensions.")
 
         alpha_shape = tuple(int(dim) for dim in self.desc["alpha_shape"])
-        block_size = int(np.prod(alpha_shape))
-        if block_size <= 0:
+        total_alpha = int(np.prod(alpha_shape))
+        if total_alpha <= 0:
             raise ValueError("alpha_shape must contain positive dimensions.")
+        if total_alpha % num_pixels != 0:
+            raise ValueError(
+                f"alpha_shape total element count ({total_alpha}) must be a multiple of "
+                f"num_pixels ({num_pixels}) derived from input_shape {input_shape}."
+            )
+        block_size = total_alpha // num_pixels
 
-        scalar_value = float(self.desc["scalar_input_value"])
+        # Scalar input values: a single value per pixel. Single-pixel descriptors
+        # (num_pixels == 1) use the original 'scalar_input_value' field; multi-pixel
+        # descriptors provide one value per pixel via hint.extras.input_values.
+        if "scalar_input_value" in self.desc:
+            scalar_values = [float(self.desc["scalar_input_value"])]
+        else:
+            extras = self.desc.get("hint", {}).get("extras", {})
+            input_values = extras.get("input_values")
+            if input_values is None:
+                raise ValueError(
+                    "PReLUScalar requires 'scalar_input_value' (single pixel) or "
+                    "hint.extras.input_values (one value per pixel, multi-pixel)."
+                )
+            scalar_values = [float(v) for v in input_values]
+
+        if len(scalar_values) != num_pixels:
+            raise ValueError(
+                f"Number of scalar input values ({len(scalar_values)}) must match "
+                f"num_pixels ({num_pixels}) derived from input_shape {input_shape}."
+            )
+        scalar_float = np.asarray(scalar_values, dtype=np.float32)
 
         alpha_values = self.desc.get("alpha_values")
         if alpha_values is None:
             extras = self.desc.get("hint", {}).get("extras", {})
             alpha_values = extras.get("alpha_values")
 
-        alpha_float = self._resolve_alpha_values(alpha_shape, alpha_values)
-        scalar_float = np.full(input_shape, scalar_value, dtype=np.float32)
+        alpha_float = self._resolve_alpha_values(alpha_shape, alpha_values).reshape(num_pixels, block_size)
 
         input_scale = float(self.desc.get("input_scale", 0.125))
         alpha_scale = float(self.desc.get("alpha_scale", 0.125))
@@ -111,7 +137,7 @@ class OpPReLUScalar(OperationBase):
         output_zero_point = int(self.desc.get("output_zero_point", 0))
 
         scalar_q = self._quantize_s8(scalar_float, input_scale, input_zero_point)
-        alpha_q = self._quantize_s8(alpha_float, alpha_scale, alpha_zero_point)
+        alpha_q = self._quantize_s8(alpha_float, alpha_scale, alpha_zero_point).reshape(num_pixels, block_size)
 
         output_multiplier_identity, output_shift_identity = calculate_multiplier_shift(input_scale / output_scale)
         output_multiplier_alpha, output_shift_alpha = calculate_multiplier_shift((input_scale * alpha_scale) / output_scale)
@@ -120,38 +146,42 @@ class OpPReLUScalar(OperationBase):
         alpha_offset = -alpha_zero_point
         output_offset = output_zero_point
 
-        input_value = int(scalar_q.reshape(-1)[0]) + input_offset
-        expected = np.zeros((block_size,), dtype=np.int32)
-        if input_value >= 0:
-            out = self._requantize_np(
-                np.array([input_value], dtype=np.int32),
-                output_multiplier_identity,
-                output_shift_identity,
-            )[0] + output_offset
-            expected.fill(int(out))
-        else:
-            alpha_centered = alpha_q.reshape(-1).astype(np.int32) + alpha_offset
-            prod = alpha_centered * int(input_value)
-            expected = self._requantize_np(prod, output_multiplier_alpha, output_shift_alpha) + output_offset
-
-        expected_q = np.clip(expected, -128, 127).astype(np.int8)
+        expected_q = np.zeros((num_pixels, block_size), dtype=np.int8)
+        for pixel in range(num_pixels):
+            input_value = int(scalar_q[pixel]) + input_offset
+            if input_value >= 0:
+                out = self._requantize_np(
+                    np.array([input_value], dtype=np.int32),
+                    output_multiplier_identity,
+                    output_shift_identity,
+                )[0] + output_offset
+                pixel_expected = np.full(block_size, int(out), dtype=np.int32)
+            else:
+                alpha_centered = alpha_q[pixel].astype(np.int32) + alpha_offset
+                prod = alpha_centered * int(input_value)
+                pixel_expected = self._requantize_np(prod, output_multiplier_alpha, output_shift_alpha) + output_offset
+            expected_q[pixel] = np.clip(pixel_expected, -128, 127).astype(np.int8)
 
         # Keep Keras-based reference generation in place for parity diagnostics.
-        scalar_input = tf.keras.Input(shape=input_shape[1:], dtype=tf.float32, name="scalar")
-        alpha_input = tf.keras.Input(shape=alpha_shape[1:], dtype=tf.float32, name="alpha")
+        scalar_input = tf.keras.Input(shape=(1,), dtype=tf.float32, name="scalar")
+        alpha_input = tf.keras.Input(shape=(block_size,), dtype=tf.float32, name="alpha")
         reference_layer = _ScalarInputPreluReference(name="prelu_scalar_reference")
         ref_model = tf.keras.Model([scalar_input, alpha_input], reference_layer([scalar_input, alpha_input]))
         ref_float = ref_model(
-            [tf.constant(scalar_float, dtype=tf.float32), tf.constant(alpha_float, dtype=tf.float32)],
+            [
+                tf.constant(scalar_float.reshape(num_pixels, 1), dtype=tf.float32),
+                tf.constant(alpha_float, dtype=tf.float32),
+            ],
             training=False,
         ).numpy()
         ref_q = self._quantize_s8(ref_float, output_scale, output_zero_point).reshape(-1)
-        reference_delta = int(np.max(np.abs(ref_q.astype(np.int16) - expected_q.astype(np.int16)))) if ref_q.size else 0
+        reference_delta = int(np.max(np.abs(ref_q.astype(np.int16) - expected_q.reshape(-1).astype(np.int16)))) if ref_q.size else 0
 
         builder = TemplateContextBuilder()
         context = {
             "name": name,
             "prefix": name,
+            "num_pixels": num_pixels,
             "scalar_array": builder.format_array_as_c_literal(scalar_q.reshape(-1)),
             "alpha_array": builder.format_array_as_c_literal(alpha_q.reshape(-1)),
             "expected_output_array": builder.format_array_as_c_literal(expected_q.reshape(-1)),

--- a/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
+++ b/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
@@ -431,7 +431,16 @@ class OpFullyConnected(OperationBase):
         
         # Prepare weight quantization dict
         if weight_quant is None:
-            weight_quant = output_quant  # Fallback to output quantization
+            # No weight-tensor quantization could be recovered from the
+            # converted model. Silently substituting the output tensor's
+            # quantization would produce incorrect per-channel/per-tensor
+            # weight scales and a wrong multiplier, potentially masking a real
+            # kernel/golden mismatch. Fail loudly instead.
+            raise RuntimeError(
+                f"FullyConnected descriptor '{name}' weight quantization could "
+                "not be recovered from the converted TFLite model; refusing to "
+                "substitute unrelated output quantization"
+            )
         
         weight_quant_dict = {
             'scale': weight_quant.get('scale', 1.0),
@@ -526,15 +535,26 @@ class OpFullyConnected(OperationBase):
         elif weights is not None and len(weights.shape) == 2:
             correct_output_units = int(weights.shape[0])
             batch_size = int(output_shape[0]) if len(output_shape) >= 1 else int(input_shape[0])
-            
+
+            if len(output_shape) == 2 and output_shape[1] != correct_output_units:
+                # The converter/LiteRT-reported output shape disagrees with the
+                # weight tensor's output-unit dimension. Silently rewriting
+                # output_dims from the weight shape would hide a real
+                # converter/kernel contract error behind an auto-corrected
+                # harness. Fail loudly instead.
+                raise RuntimeError(
+                    f"FullyConnected descriptor '{name}' has LiteRT "
+                    f"output_shape[1] ({output_shape[1]}) that disagrees with "
+                    f"weights.shape[0] ({correct_output_units}); refusing to "
+                    "silently override output dims"
+                )
+
             output_dims = {
                 'n': batch_size,
                 'h': 1,
                 'w': 1,
                 'c': correct_output_units
             }
-            if len(output_shape) == 2 and output_shape[1] != correct_output_units:
-                print(f"Warning: LiteRT output_shape[1] ({output_shape[1]}) != weights.shape[0] ({correct_output_units}). Using weights shape.")
         elif len(output_shape) == 2:
             output_dims = {
                 'n': int(output_shape[0]),

--- a/helia_core_tester/generation/ops/QuantizationFunctions/dequantize.py
+++ b/helia_core_tester/generation/ops/QuantizationFunctions/dequantize.py
@@ -111,8 +111,13 @@ class OpDequantize(QuantizationFamilyBase):
             # Handle array/list scales (take first element for per-tensor assumption)
             if isinstance(input_scale, (list, np.ndarray)):
                 if len(input_scale) > 1:
-                    print(f"Warning: Input has per-channel quantization with {len(input_scale)} scales. Using first scale.")
-                    input_scale = input_scale[0]
+                    raise ValueError(
+                        f"Dequantize descriptor '{name}' has per-channel input "
+                        f"quantization with {len(input_scale)} scales, but "
+                        "arm_dequantize_s8_f32/arm_dequantize_s16_f32 are "
+                        "per-tensor kernels; using channel-0's scale for all "
+                        "channels would silently corrupt the golden output"
+                    )
                 elif len(input_scale) == 1:
                     input_scale = input_scale[0]
                 else:
@@ -121,8 +126,13 @@ class OpDequantize(QuantizationFamilyBase):
                 
             if isinstance(input_zp, (list, np.ndarray)):
                 if len(input_zp) > 1:
-                    print(f"Warning: Input has per-channel quantization with {len(input_zp)} zero points. Using first zero point.")
-                    input_zp = input_zp[0]
+                    raise ValueError(
+                        f"Dequantize descriptor '{name}' has per-channel input "
+                        f"quantization with {len(input_zp)} zero points, but "
+                        "arm_dequantize_s8_f32/arm_dequantize_s16_f32 are "
+                        "per-tensor kernels; using channel-0's zero point for all "
+                        "channels would silently corrupt the golden output"
+                    )
                 elif len(input_zp) == 1:
                     input_zp = input_zp[0]
                 else:
@@ -170,31 +180,17 @@ class OpDequantize(QuantizationFamilyBase):
                 else:
                     output_data = np.clip(output_data, 0.0, 6.0)
         else:
-            input_shape = tuple(self.desc['input_shape'])
-            if kernel_info["input_c_type"] == "int8_t":
-                np_in_dtype = np.int8
-                qmin, qmax = -128, 127
-                input_scale = 1.0 / 128.0
-                input_zp = 0
-            elif kernel_info["input_c_type"] == "int16_t":
-                np_in_dtype = np.int16
-                qmin, qmax = -32768, 32767
-                input_scale = 1.0 / 32768.0
-                input_zp = 0
-            else:
-                raise ValueError(f"Unsupported input_c_type: {kernel_info['input_c_type']}")
-
-            input_data_float = self._sample_uniform(input_shape)
-
-            input_q = np.round(input_data_float / float(input_scale) + float(input_zp)).astype(np.int32)
-            input_q = np.clip(input_q, qmin, qmax).astype(np_in_dtype)
-
-            output_data = (input_q.astype(np.float32) - float(input_zp)) * float(input_scale)
-            if has_activation:
-                if activation_str == 'RELU':
-                    output_data = np.maximum(output_data, 0.0)
-                else:
-                    output_data = np.clip(output_data, 0.0, 6.0)
+            # No converted TFLite model is available to source real quantization
+            # parameters from. Dequantize is allow_no_tflite(), but silently
+            # substituting hardcoded default scale/zero-point (unrelated to the
+            # descriptor or converter) would produce a golden vector quantized
+            # with the wrong parameters. Fail loudly instead.
+            raise RuntimeError(
+                f"Dequantize descriptor '{name}' has no converted TFLite model "
+                "(conversion unavailable or failed) and no explicit descriptor "
+                "quantization parameters; refusing to substitute hardcoded "
+                "default input scale/zero-point"
+            )
         
         # Format arrays
         input_array_str = builder.format_array_as_c_literal(input_q)

--- a/helia_core_tester/generation/ops/QuantizationFunctions/quantize.py
+++ b/helia_core_tester/generation/ops/QuantizationFunctions/quantize.py
@@ -17,21 +17,44 @@ class OpQuantize(QuantizationFamilyBase):
 
     def allow_no_tflite(self) -> bool:
         return True
+
+    def primary_execution_dtype(self) -> str:
+        """Quantize converts an FP32 input to a quantized output, so the
+        conversion/quantization target dtype is the *output* dtype, not the
+        input. The shared base implementation defaults to the input dtype
+        (correct for unary/activation-like ops), which for Quantize is always
+        FP32 -- this previously caused the shared TFLite converter to skip
+        int8/int16 quantization entirely and emit a fully float32 model.
+        """
+        resolved = self.resolved_tensor_dtypes()
+        if "output" in resolved:
+            return resolved["output"]
+        return super().primary_execution_dtype()
     
     def build_keras_model(self) -> tf.keras.Model:
         """Build Keras model for Quantize operation.
         
         Creates a model that can be quantized by TFLite converter.
-        Uses an identity operation (Lambda layer) to preserve input values.
+        Uses an identity-weight Dense layer to preserve input values.
         """
         input_shape = self.desc['input_shape']
         
         # Build model with float32 inputs (will be quantized later)
         inputs = tf.keras.Input(shape=input_shape[1:], dtype=tf.float32, name='input')
-        
-        # Use Lambda layer to create an identity operation
-        # This will be quantized by TFLite converter
-        x = tf.keras.layers.Lambda(lambda x: x, name='identity')(inputs)
+
+        # A pure identity (Lambda) op has no real computation, so the TFLite
+        # converter fully constant-folds it away into a single float32
+        # passthrough tensor before quantization can be inserted -- even when
+        # inference_output_type=int8/int16 is explicitly requested. Following
+        # the reference CMSIS-NN test generator
+        # (RefactoredTestGen/Lib/op_quantize.py:generate_keras_model), use an
+        # identity-weight Dense layer instead: a real op the converter must
+        # actually quantize.
+        flat = tf.keras.layers.Flatten(name='flatten')(inputs)
+        num_features = int(flat.shape[-1])
+        dense = tf.keras.layers.Dense(units=num_features, use_bias=False, activation=None, name='identity')
+        x = dense(flat)
+        dense.set_weights([np.eye(num_features, dtype=np.float32)])
         
         # Apply activation if specified
         activation_str = self.desc.get('activation', 'NONE')
@@ -84,26 +107,44 @@ class OpQuantize(QuantizationFamilyBase):
 
     def _extract_per_tensor_output_quantization(self, output_qp: dict) -> tuple[float, int]:
         """Return per-tensor output quantization from LiteRT metadata."""
-        output_scale = 1.0
-        output_zp = 0
+        scales = output_qp.get("scales", None) if output_qp else None
+        zero_points = output_qp.get("zero_points", None) if output_qp else None
 
-        if output_qp:
-            scales = output_qp.get("scales", None)
-            zero_points = output_qp.get("zero_points", None)
+        # Some LiteRT paths emit empty quant metadata for identity-style models.
+        # Silently falling back to a default scale/zero-point would produce a
+        # golden vector quantized with parameters unrelated to what the
+        # converter actually chose. Fail loudly instead.
+        if isinstance(scales, (list, tuple, np.ndarray)):
+            if len(scales) == 0:
+                raise ValueError(
+                    "Quantize output quantization metadata is missing per-tensor "
+                    "scale (empty scales array); refusing to substitute a default "
+                    "output scale"
+                )
+            output_scale = float(scales[0])
+        elif scales is not None:
+            output_scale = float(scales)
+        else:
+            raise ValueError(
+                "Quantize output quantization metadata is missing per-tensor "
+                "scale; refusing to substitute a default output scale"
+            )
 
-            # Some LiteRT paths emit empty quant metadata for identity-style models.
-            # Fall back to safe defaults so codegen can proceed.
-            if isinstance(scales, (list, tuple, np.ndarray)):
-                if len(scales) > 0:
-                    output_scale = float(scales[0])
-            elif scales is not None:
-                output_scale = float(scales)
-
-            if isinstance(zero_points, (list, tuple, np.ndarray)):
-                if len(zero_points) > 0:
-                    output_zp = int(zero_points[0])
-            elif zero_points is not None:
-                output_zp = int(zero_points)
+        if isinstance(zero_points, (list, tuple, np.ndarray)):
+            if len(zero_points) == 0:
+                raise ValueError(
+                    "Quantize output quantization metadata is missing per-tensor "
+                    "zero point (empty zero_points array); refusing to substitute "
+                    "a default output zero point"
+                )
+            output_zp = int(zero_points[0])
+        elif zero_points is not None:
+            output_zp = int(zero_points)
+        else:
+            raise ValueError(
+                "Quantize output quantization metadata is missing per-tensor "
+                "zero point; refusing to substitute a default output zero point"
+            )
 
         return output_scale, output_zp
     
@@ -149,32 +190,17 @@ class OpQuantize(QuantizationFamilyBase):
             output_data = interpreter.get_tensor(output_details[0]['index'])
             output_data = np.array(output_data)
         else:
-            input_shape = tuple(self.desc['input_shape'])
-            output_shape = input_shape
-
-            if kernel_info["output_c_type"] == "int8_t":
-                output_scale = 1.0 / 128.0
-                output_zp = 0
-                qmin, qmax = -128, 127
-                out_dtype = np.int8
-            else:
-                output_scale = 1.0 / 32768.0
-                output_zp = 0
-                qmin, qmax = -32768, 32767
-                out_dtype = np.int16
-
-            input_data = self._sample_uniform(input_shape)
-
-            if has_activation:
-                if activation_str == 'RELU':
-                    activated = np.maximum(input_data, 0.0)
-                else:
-                    activated = np.clip(input_data, 0.0, 6.0)
-            else:
-                activated = input_data
-
-            output_q = np.rint(activated / float(output_scale) + float(output_zp)).astype(np.int32)
-            output_data = np.clip(output_q, qmin, qmax).astype(out_dtype)
+            # No converted TFLite model is available to source real quantization
+            # parameters from. Quantize is allow_no_tflite(), but silently
+            # substituting hardcoded default scale/zero-point (unrelated to the
+            # descriptor or converter) would produce a golden vector quantized
+            # with the wrong parameters. Fail loudly instead.
+            raise RuntimeError(
+                f"Quantize descriptor '{name}' has no converted TFLite model "
+                "(conversion unavailable or failed) and no explicit descriptor "
+                "quantization parameters; refusing to substitute hardcoded "
+                "default output scale/zero-point"
+            )
         
         # Format arrays
         input_array_str = builder.format_array_as_c_literal(input_data)

--- a/helia_core_tester/generation/test_ops.py
+++ b/helia_core_tester/generation/test_ops.py
@@ -275,7 +275,10 @@ def generate_test(
                 "exception": repr(e),
                 "traceback": traceback.format_exc(),
             })
-        # Continue anyway - C generation is optional during transition
+        # Do not silently continue: an unexpected failure to generate C/H files
+        # must fail this descriptor's generation (and therefore the overall
+        # generation run) rather than being counted as successfully generated.
+        raise
 
 
 def test_generation(test_filters):
@@ -491,6 +494,14 @@ def test_generation(test_filters):
     }
     (report_dir / "generation_summary.json").write_text(json.dumps(summary, indent=2))
     assert generated_count > 0 or skipped_entries, "No TFLite models were generated"
+    assert not conversion_failures, (
+        f"Conversion failures occurred for {len(conversion_failures)} descriptor(s): "
+        f"{', '.join(str(f.get('name')) for f in conversion_failures)}"
+    )
+    assert not generation_failures, (
+        f"Generation failures occurred for {len(generation_failures)} descriptor(s): "
+        f"{', '.join(str(f.get('name')) for f in generation_failures)}"
+    )
 
 
 def _write_manifest_and_cmake(

--- a/helia_core_tester/tests/test_quantize_dequantize_fallback.py
+++ b/helia_core_tester/tests/test_quantize_dequantize_fallback.py
@@ -51,25 +51,24 @@ def _dequantize_desc(name: str, activation: str, dtype: str) -> dict:
     }
 
 
-def _assert_generated(output_dir: Path, name: str, suffix: str) -> None:
-    header = output_dir / "includes" / f"{name}_{suffix}.h"
-    source = output_dir / f"{name}_{suffix}.c"
-    assert header.exists()
-    assert source.exists()
-
-
-def test_quantize_generates_without_tflite(tmp_path: Path) -> None:
+def test_quantize_fails_without_tflite(tmp_path: Path) -> None:
+    """Quantize has no explicit descriptor quant params, so when no converted
+    TFLite model is available, generation must fail loudly (COR-008) rather
+    than silently substitute a hardcoded default output scale/zero-point."""
     desc = _quantize_desc("quantize_fp32_to_s8_basic", "NONE", "S8")
     op = OpQuantize(desc, seed=1, target_cpu="cortex-m55")
-    op.generate_c_files(tmp_path)
-    _assert_generated(tmp_path, desc["name"], "quantize")
+    with pytest.raises(RuntimeError, match="no converted TFLite model"):
+        op.generate_c_files(tmp_path)
 
 
-def test_dequantize_generates_without_tflite(tmp_path: Path) -> None:
+def test_dequantize_fails_without_tflite(tmp_path: Path) -> None:
+    """Dequantize has no explicit descriptor quant params, so when no converted
+    TFLite model is available, generation must fail loudly (COR-008) rather
+    than silently substitute a hardcoded default input scale/zero-point."""
     desc = _dequantize_desc("dequantize_s8_to_fp32_basic", "NONE", "S8")
     op = OpDequantize(desc, seed=1, target_cpu="cortex-m55")
-    op.generate_c_files(tmp_path)
-    _assert_generated(tmp_path, desc["name"], "dequantize")
+    with pytest.raises(RuntimeError, match="no converted TFLite model"):
+        op.generate_c_files(tmp_path)
 
 
 def test_dequantize_name_does_not_drive_activation() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+testpaths = ["helia_core_tester/tests"]
 filterwarnings = [
     'ignore:In the future `np.object` will be defined as the corresponding NumPy scalar\.:FutureWarning:keras\.src\.export\.tf2onnx_lib',
     'ignore:Statistics for quantized inputs were expected, but not specified; continuing anyway\.:UserWarning:tensorflow\.lite\.python\.convert',


### PR DESCRIPTION
Enhance PReLU and PReLUScalar Operations with Error Handling and Scalar Input Support

- Restored PReLUScalar configurations in prelu.yaml to handle scalar inputs independently.
- Updated prelu_scalar.yaml to define new PReLUScalar operations with scalar input values.
- Modified prelu.c.j2 and prelu_scalar.c.j2 templates to validate expected statuses during test case runs.
- Enhanced build.py to capture detailed error information during build failures.
- Improved clean.py to ensure failed removals are reported as errors.
- Updated descriptors.py to enforce validation rules for PReLUScalar, ensuring scalar input values are provided.
- Enhanced prelu.py to handle argument errors and validate broadcast support for PReLU operations.
- Updated prelu_scalar.py to support multiple scalar input values for multi-pixel descriptors.
- Improved fully_connected.py to raise errors for mismatched output dimensions during model conversion.
- Enhanced dequantize.py and quantize.py to fail loudly when quantization parameters are missing.
- Updated test_quantize_dequantize_fallback.py to ensure tests fail when expected conditions are not met.
- Modified pyproject.toml to specify test paths for pytest.