### PR TITLE
test(add): add mixed-broadcast height regression coverage for arm_add_s8/s16

### DIFF
--- a/assets/descriptors/BasicMathFunctions/add.yaml
+++ b/assets/descriptors/BasicMathFunctions/add.yaml
@@ -207,3 +207,43 @@ hint:
   call_style: per_tensor
 input_1_shape: [1, 1, 1, 3]
 input_2_shape: [1, 1, 2, 1]
+---
+operator: Add
+name: add_row_scalar1_matched_height_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [2, 3, 1, 1]
+input_2_shape: [2, 3, 1, 5]
+---
+operator: Add
+name: add_row_scalar2_matched_height_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [2, 3, 1, 5]
+input_2_shape: [2, 3, 1, 1]
+---
+operator: Add
+name: add_row_scalar1_matched_height_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [2, 3, 1, 1]
+input_2_shape: [2, 3, 1, 5]
+---
+operator: Add
+name: add_row_scalar2_matched_height_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [2, 3, 1, 5]
+input_2_shape: [2, 3, 1, 1]


### PR DESCRIPTION
## Summary

Adds four `Add` descriptors that reproduce the quantized mixed-broadcast row-scalar regression fixed in [ns-cmsis-nn#213](https://github.com/AmbiqAI/ns-cmsis-nn/pull/213) (`arm_add_s8` / `arm_add_s16`).

## Root cause covered

The bug occurs when the scalar-broadcast side has matched height (`in_h == out_h`) and width 1 with `wd == 0`, so `hd == 0` even though the scalar-side row pointer still needs to advance to the next row's value each iteration. The old code either never advanced the pointer (main) or advanced it unconditionally (regressed cleanup), producing wrong results for this specific shape family.

## New descriptors (`BasicMathFunctions/add.yaml`)

- `add_row_scalar1_matched_height_s8` / `_s16`: `[N,H,1,1] + [N,H,1,C]`
- `add_row_scalar2_matched_height_s8` / `_s16`: `[N,H,1,C] + [N,H,1,1]`

## Validation

Ran via `uv run helia_core_tester full` inside the `ghcr.io/ambiqai/ns-cmsis-nn-ci:latest` container (Corstone-300 FVP, GCC toolchain):

- Against unpatched `arm_add_s8`/`arm_add_s16` (ns-cmsis-nn `main`): all 4 new tests **FAIL** (10 element mismatches each), confirming they reproduce the regression.
- Against the fix in ns-cmsis-nn PR #213: all 4 new tests **PASS**.
- Full int suite remains green with the new tests included:
  - cortex-m55: 675/675 passed
  - cortex-m4: 675/675 passed
  - cortex-m0: 664/664 passed

No other files were changed; only new descriptor entries were appended to the existing `add.yaml`.