### PR TITLE
feat: Add FP16 test coverage for arm_split_f16, arm_strided_slice_f16, arm_elementwise_sub_f16

### DIFF
--- a/assets/descriptors/BasicMathFunctions/sub_float.yaml
+++ b/assets/descriptors/BasicMathFunctions/sub_float.yaml
@@ -1,0 +1,26 @@
+operator: Sub
+name: sub_float_default_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_1_shape: [1, 4, 4, 8]
+input_2_shape: [1, 4, 4, 8]
+---
+operator: Sub
+name: sub_float_tail_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_1_shape: [1, 1, 1, 9]
+input_2_shape: [1, 1, 1, 9]
+---
+operator: Sub
+name: sub_float_odd_block_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_1_shape: [1, 3, 5, 3]
+input_2_shape: [1, 3, 5, 3]

--- a/assets/descriptors/ConcatenationFunctions/split_float.yaml
+++ b/assets/descriptors/ConcatenationFunctions/split_float.yaml
@@ -1,0 +1,44 @@
+operator: Split
+name: split_float_channels_pairs_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 1
+- 2
+- 2
+- 4
+axis: -1
+num_splits: 2
+---
+operator: Split
+name: split_float_height_triple_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 1
+- 6
+- 4
+- 2
+axis: 1
+num_splits: 3
+---
+operator: Split
+name: split_float_v_channels_mixed_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 1
+- 2
+- 2
+- 6
+axis: -1
+size_splits:
+- 2
+- 1
+- 3

--- a/assets/descriptors/StridedSliceFunctions/strided_slice_float.yaml
+++ b/assets/descriptors/StridedSliceFunctions/strided_slice_float.yaml
@@ -1,0 +1,134 @@
+operator: StridedSlice
+name: strided_slice_float_whole_slab_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 2
+- 3
+- 4
+- 2
+begin:
+- 1
+- 0
+- 0
+- 0
+end:
+- 2
+- 3
+- 4
+- 2
+strides:
+- 1
+- 1
+- 1
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_batch_slice_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 3
+- 4
+- 3
+- 2
+begin:
+- 0
+- 1
+- 0
+- 0
+end:
+- 3
+- 3
+- 3
+- 2
+strides:
+- 2
+- 1
+- 1
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_crop_width_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 1
+- 3
+- 4
+- 2
+begin:
+- 0
+- 0
+- 0
+- 0
+end:
+- 1
+- 3
+- 2
+- 2
+strides:
+- 1
+- 1
+- 1
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_stride2_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 1
+- 3
+- 4
+- 2
+begin:
+- 0
+- 0
+- 0
+- 0
+end:
+- 1
+- 3
+- 4
+- 2
+strides:
+- 1
+- 1
+- 2
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_general_neg_stride_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape:
+- 1
+- 3
+- 4
+- 4
+begin:
+- 0
+- 2
+- 3
+- 3
+end:
+- 1
+- 0
+- 0
+- 0
+strides:
+- 1
+- -1
+- -1
+- -2

--- a/assets/templates/BasicMathFunctions/sub/sub.c.j2
+++ b/assets/templates/BasicMathFunctions/sub/sub.c.j2
@@ -11,6 +11,16 @@ int32_t {{ prefix }}_{{ name }}_run(
     {{ output_dtype }}* __restrict output
 ) {
     // Call subtract kernel
+    {% if float_kernel %}
+    arm_cmsis_nn_status kernel_status = {{ kernel_fn }}(
+        input1,
+        input2,
+        output,
+        {{ out_activation_min_literal }},
+        {{ out_activation_max_literal }},
+        {{ block_size }}
+    );
+    {% else %}
     arm_cmsis_nn_status kernel_status = {{ kernel_fn }}(
 {% if call_style and call_style|lower == 'elementwise' %}
         input1,
@@ -50,6 +60,7 @@ int32_t {{ prefix }}_{{ name }}_run(
         {{ out_activation_max }}  // out_activation_max
 {% endif %}
     );
+    {% endif %}
     
     return kernel_status;
 }

--- a/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
@@ -22,11 +22,13 @@ class OpSub(BinaryBasicMathBase):
     def convert_to_tflite(self, model, out_path: str, rep_seed: int) -> None:
         from helia_core_tester.generation.utils.litert_builder import build_sub_op
 
-        activation_dtype = self.desc.get("activation_dtype", "S8")
+        activation_dtype = self.tensor_dtype("input", default="S8")
         if activation_dtype == "S8":
             dtype = "int8"
         elif activation_dtype == "S16":
             dtype = "int16"
+        elif activation_dtype == "FP16":
+            dtype = "float16"
         else:
             raise NotImplementedError(f"Unsupported Sub dtype: {activation_dtype}")
 
@@ -47,13 +49,14 @@ class OpSub(BinaryBasicMathBase):
         Returns:
             Dictionary with kernel_fn, input_c_type, output_c_type
         """
-        activation_dtype = self.desc.get('activation_dtype', 'S8')
-        
+        activation_dtype = self.tensor_dtype("input", default="S8")
+
         if activation_dtype == 'S8':
             return {
                 'kernel_fn': 'arm_sub_s8',
                 'input_c_type': 'int8_t',
-                'output_c_type': 'int8_t'
+                'output_c_type': 'int8_t',
+                'float_kernel': False,
             }
         elif activation_dtype == 'S16':
             call_style = self.desc.get("hint", {}).get("call_style", "")
@@ -61,12 +64,21 @@ class OpSub(BinaryBasicMathBase):
                 return {
                     'kernel_fn': 'arm_elementwise_sub_s16',
                     'input_c_type': 'int16_t',
-                    'output_c_type': 'int16_t'
+                    'output_c_type': 'int16_t',
+                    'float_kernel': False,
                 }
             return {
                 'kernel_fn': 'arm_sub_s16',
                 'input_c_type': 'int16_t',
-                'output_c_type': 'int16_t'
+                'output_c_type': 'int16_t',
+                'float_kernel': False,
+            }
+        elif activation_dtype == 'FP16':
+            return {
+                'kernel_fn': 'arm_elementwise_sub_f16',
+                'input_c_type': 'float16_t',
+                'output_c_type': 'float16_t',
+                'float_kernel': True,
             }
         else:
             raise NotImplementedError(f"Unsupported Sub dtype: {activation_dtype}")
@@ -124,79 +136,97 @@ class OpSub(BinaryBasicMathBase):
         input2_dims = builder.nhwc_to_cmsis_dims(input2_shape)
         output_dims = builder.nhwc_to_cmsis_dims(output_shape)
         
-        activation_dtype = self.desc.get('activation_dtype', 'S8')
-        activation_min, activation_max = activation_bounds(activation_dtype)
-        addsub_qparams = elementwise_addsub_quant_params(
-            input1_scale=float(input1_scale),
-            input2_scale=float(input2_scale),
-            output_scale=float(output_scale),
-            activation_dtype=activation_dtype,
-        )
-        mult1 = addsub_qparams["input1_mult"]
-        shift1 = addsub_qparams["input1_shift"]
-        mult2 = addsub_qparams["input2_mult"]
-        shift2 = addsub_qparams["input2_shift"]
-        output_mult = addsub_qparams["out_mult"]
-        output_shift = addsub_qparams["out_shift"]
-        left_shift = addsub_qparams["left_shift"]
-        
-        # Generate input data and quantize
-        rng_state = self.rng.__getstate__()
-        self.rng = np.random.default_rng(self.seed)
-        
-        input1_data = self.rng.uniform(-1.0, 1.0, size=input1_shape).astype(np.float32)
-        input2_data = self.rng.uniform(-1.0, 1.0, size=input2_shape).astype(np.float32)
-        
-        self.rng.__setstate__(rng_state)
-        
-        # Quantize inputs
-        if kernel_info["input_c_type"] == "int8_t":
-            np_in_dtype = np.int8
-            qmin, qmax = -128, 127
-        elif kernel_info["input_c_type"] == "int16_t":
-            np_in_dtype = np.int16
-            qmin, qmax = -32768, 32767
-        else:
-            raise ValueError(f"Unsupported input_c_type: {kernel_info['input_c_type']}")
-        
-        input1_q = np.round(input1_data / float(input1_scale) + float(input1_zp)).astype(np.int32)
-        input1_q = np.clip(input1_q, qmin, qmax).astype(np_in_dtype)
-        
-        input2_q = np.round(input2_data / float(input2_scale) + float(input2_zp)).astype(np.int32)
-        input2_q = np.clip(input2_q, qmin, qmax).astype(np_in_dtype)
-        
-        # Run inference using LiteRT interpreter when shapes match (no broadcast).
-        # LiteRT broadcasting can abort in some runtimes, so fall back to a local
-        # quantized simulation for broadcasted shapes.
-        if input1_shape == input2_shape:
-            interpreter = self.load_litert_interpreter(str(tflite_path))
-            input_details = interpreter.get_input_details()
-            output_details = interpreter.get_output_details()
+        activation_dtype = self.tensor_dtype("input", default="S8")
 
-            interpreter.set_tensor(input_details[0]['index'], input1_q)
-            interpreter.set_tensor(input_details[1]['index'], input2_q)
-            interpreter.invoke()
-            output_data = interpreter.get_tensor(output_details[0]['index'])
-            output_data = np.array(output_data)
+        if kernel_info["float_kernel"]:
+            # arm_elementwise_sub_f16 has no broadcast support, so both inputs
+            # must already share the same shape.
+            activation_min = float(self.desc.get("act_min", -1.0e30))
+            activation_max = float(self.desc.get("act_max", 1.0e30))
+            input1_q = self._sample_uniform(input1_shape, dtype=np.float16)
+            input2_q = self._sample_uniform(input2_shape, dtype=np.float16)
+            output_data = np.clip(
+                input1_q.astype(np.float32) - input2_q.astype(np.float32),
+                activation_min,
+                activation_max,
+            ).astype(np.float16)
+            activation_min_literal = builder.format_float_literal(activation_min)
+            activation_max_literal = builder.format_float_literal(activation_max)
+            mult1 = shift1 = mult2 = shift2 = output_mult = output_shift = left_shift = 0
+            input1_zp = input2_zp = output_zp = 0
         else:
-            output_data = self._simulate_sub_quantized(
-                input1_q,
-                input2_q,
-                input1_offset=-int(input1_zp),
-                input2_offset=-int(input2_zp),
-                input1_mult=int(mult1),
-                input1_shift=int(shift1),
-                input2_mult=int(mult2),
-                input2_shift=int(shift2),
-                left_shift=int(left_shift),
-                out_offset=int(output_zp),
-                out_mult=int(output_mult),
-                out_shift=int(output_shift),
-                out_activation_min=int(activation_min),
-                out_activation_max=int(activation_max),
-                out_dtype=np_in_dtype,
+            activation_min, activation_max = activation_bounds(activation_dtype)
+            addsub_qparams = elementwise_addsub_quant_params(
+                input1_scale=float(input1_scale),
+                input2_scale=float(input2_scale),
+                output_scale=float(output_scale),
+                activation_dtype=activation_dtype,
             )
-        
+            mult1 = addsub_qparams["input1_mult"]
+            shift1 = addsub_qparams["input1_shift"]
+            mult2 = addsub_qparams["input2_mult"]
+            shift2 = addsub_qparams["input2_shift"]
+            output_mult = addsub_qparams["out_mult"]
+            output_shift = addsub_qparams["out_shift"]
+            left_shift = addsub_qparams["left_shift"]
+
+            # Generate input data and quantize
+            rng_state = self.rng.__getstate__()
+            self.rng = np.random.default_rng(self.seed)
+
+            input1_data = self.rng.uniform(-1.0, 1.0, size=input1_shape).astype(np.float32)
+            input2_data = self.rng.uniform(-1.0, 1.0, size=input2_shape).astype(np.float32)
+
+            self.rng.__setstate__(rng_state)
+
+            # Quantize inputs
+            if kernel_info["input_c_type"] == "int8_t":
+                np_in_dtype = np.int8
+                qmin, qmax = -128, 127
+            elif kernel_info["input_c_type"] == "int16_t":
+                np_in_dtype = np.int16
+                qmin, qmax = -32768, 32767
+            else:
+                raise ValueError(f"Unsupported input_c_type: {kernel_info['input_c_type']}")
+
+            input1_q = np.round(input1_data / float(input1_scale) + float(input1_zp)).astype(np.int32)
+            input1_q = np.clip(input1_q, qmin, qmax).astype(np_in_dtype)
+
+            input2_q = np.round(input2_data / float(input2_scale) + float(input2_zp)).astype(np.int32)
+            input2_q = np.clip(input2_q, qmin, qmax).astype(np_in_dtype)
+
+            # Run inference using LiteRT interpreter when shapes match (no broadcast).
+            # LiteRT broadcasting can abort in some runtimes, so fall back to a local
+            # quantized simulation for broadcasted shapes.
+            if input1_shape == input2_shape:
+                interpreter = self.load_litert_interpreter(str(tflite_path))
+                input_details = interpreter.get_input_details()
+                output_details = interpreter.get_output_details()
+
+                interpreter.set_tensor(input_details[0]['index'], input1_q)
+                interpreter.set_tensor(input_details[1]['index'], input2_q)
+                interpreter.invoke()
+                output_data = interpreter.get_tensor(output_details[0]['index'])
+                output_data = np.array(output_data)
+            else:
+                output_data = self._simulate_sub_quantized(
+                    input1_q,
+                    input2_q,
+                    input1_offset=-int(input1_zp),
+                    input2_offset=-int(input2_zp),
+                    input1_mult=int(mult1),
+                    input1_shift=int(shift1),
+                    input2_mult=int(mult2),
+                    input2_shift=int(shift2),
+                    left_shift=int(left_shift),
+                    out_offset=int(output_zp),
+                    out_mult=int(output_mult),
+                    out_shift=int(output_shift),
+                    out_activation_min=int(activation_min),
+                    out_activation_max=int(activation_max),
+                    out_dtype=np_in_dtype,
+                )
+
         # Format arrays
         input1_array_str = builder.format_array_as_c_literal(input1_q)
         input2_array_str = builder.format_array_as_c_literal(input2_q)
@@ -229,8 +259,13 @@ class OpSub(BinaryBasicMathBase):
             'input_dtype': kernel_info["input_c_type"],
             'output_dtype': kernel_info["output_c_type"],
             'kernel_fn': kernel_info["kernel_fn"],
+            'float_kernel': kernel_info["float_kernel"],
         }
-        
+        if kernel_info["float_kernel"]:
+            context["out_activation_min_literal"] = activation_min_literal
+            context["out_activation_max_literal"] = activation_max_literal
+            context["validation_mode"] = "float"
+
         cmake_context = {
             'name': name,
             'operator': self.desc.get('operator', 'Sub'),

--- a/helia_core_tester/generation/ops/ConcatenationFunctions/split.py
+++ b/helia_core_tester/generation/ops/ConcatenationFunctions/split.py
@@ -27,6 +27,8 @@ class OpSplit(OperationBase):
             dtype = "int8"
         elif activation_dtype == "S16":
             dtype = "int16"
+        elif activation_dtype == "FP16":
+            dtype = "float16"
         else:
             raise NotImplementedError(f"Unsupported Split dtype: {activation_dtype}")
 
@@ -65,6 +67,12 @@ class OpSplit(OperationBase):
                 'kernel_fn': 'arm_split_s16',
                 'input_c_type': 'int16_t',
                 'output_c_type': 'int16_t'
+            }
+        elif activation_dtype == 'FP16':
+            return {
+                'kernel_fn': 'arm_split_f16',
+                'input_c_type': 'float16_t',
+                'output_c_type': 'float16_t'
             }
         else:
             raise NotImplementedError(f"Unsupported Split dtype: {activation_dtype}")
@@ -123,6 +131,9 @@ class OpSplit(OperationBase):
             np_in_dtype = np.int16
             qmin, qmax = -32768, 32767
             input_q = self.rng.integers(qmin, qmax + 1, size=input_shape, dtype=np_in_dtype)
+        elif kernel_info["input_c_type"] == "float16_t":
+            np_in_dtype = np.float16
+            input_q = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(np_in_dtype)
         else:
             raise ValueError(f"Unsupported input_c_type: {kernel_info['input_c_type']}")
 
@@ -164,6 +175,8 @@ class OpSplit(OperationBase):
             'output_dtype': kernel_info["output_c_type"],
             'kernel_fn': kernel_info["kernel_fn"],
         }
+        if kernel_info["input_c_type"] == "float16_t":
+            context["validation_mode"] = "float"
         
         # Render templates
         includes_api_dir = output_dir / "includes"

--- a/helia_core_tester/generation/ops/StridedSliceFunctions/strided_slice.py
+++ b/helia_core_tester/generation/ops/StridedSliceFunctions/strided_slice.py
@@ -13,7 +13,14 @@ class OpStridedSlice(OperationBase):
     """
     StridedSlice operation.
     """
-    
+
+    def needs_keras_model(self) -> bool:
+        # FP16 uses a LiteRT-only single-op model (Keras/TFLiteConverter has no
+        # reliable FP16 activation path); quantized dtypes keep the existing
+        # Keras-based pipeline.
+        activation_dtype = str(self.desc.get('activation_dtype', 'S8')).upper()
+        return activation_dtype != 'FP16'
+
     def build_keras_model(self) -> tf.keras.Model:
         """Build Keras model for StridedSlice operation."""
         input_shape = self.desc['input_shape']
@@ -53,12 +60,35 @@ class OpStridedSlice(OperationBase):
 
     def convert_to_tflite(self, model, out_path: str, rep_seed: int) -> None:
         """Convert Keras model to TFLite with quantization."""
+        activation_dtype = str(self.desc.get('activation_dtype', 'S8')).upper()
+
+        if activation_dtype == 'FP16':
+            from helia_core_tester.generation.utils.litert_builder import build_strided_slice_op
+
+            input_shape = tuple(self.desc['input_shape'])
+            begin = self.desc.get('begin', [0, 0, 0, 0])
+            end = self.desc.get('end', None)
+            strides = self.desc.get('strides', [1, 1, 1, 1])
+            shrink_axis_mask = int(self.desc.get('shrink_axis_mask', 0))
+            if end is None:
+                end = list(input_shape)
+
+            model_bytes = build_strided_slice_op(
+                input_shape=input_shape,
+                begin=begin,
+                end=end,
+                strides=strides,
+                shrink_axis_mask=shrink_axis_mask,
+                dtype="float16",
+            )
+            with open(out_path, "wb") as f:
+                f.write(model_bytes)
+            return
+
         # Create converter
         converter = tf.lite.TFLiteConverter.from_keras_model(model)
         
         # Apply quantization based on activation_dtype
-        activation_dtype = str(self.desc.get('activation_dtype', 'S8')).upper()
-        
         if activation_dtype == 'S8':
             converter.optimizations = [tf.lite.Optimize.DEFAULT]
             converter.target_spec.supported_types = [tf.int8]
@@ -123,6 +153,12 @@ class OpStridedSlice(OperationBase):
                 'kernel_fn': 'arm_strided_slice_s32',
                 'input_c_type': 'int32_t',
                 'output_c_type': 'int32_t'
+            }
+        elif activation_dtype == 'FP16':
+            return {
+                'kernel_fn': 'arm_strided_slice_f16',
+                'input_c_type': 'float16_t',
+                'output_c_type': 'float16_t'
             }
         else:
             raise NotImplementedError(f"Unsupported StridedSlice dtype: {activation_dtype}")
@@ -223,7 +259,12 @@ class OpStridedSlice(OperationBase):
         rng_state = self.rng.__getstate__()
         self.rng = np.random.default_rng(self.seed)
 
-        if kernel_info["input_c_type"] == "int32_t":
+        if kernel_info["input_c_type"] == "float16_t":
+            # StridedSlice is pure data movement, so the golden output can be
+            # computed directly via numpy slicing without invoking a TFLite
+            # interpreter (which has no reliable FP16 activation path).
+            input_q = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(np.float16)
+        elif kernel_info["input_c_type"] == "int32_t":
             input_q = self.rng.integers(-1000, 1001, size=input_shape, dtype=np.int32)
         else:
             input_data = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(np.float32)
@@ -256,24 +297,40 @@ class OpStridedSlice(OperationBase):
             input_q = np.clip(input_q, qmin, qmax).astype(np_in_dtype)
 
         self.rng.__setstate__(rng_state)
-        
-        # Run inference using LiteRT interpreter
-        interpreter = self.load_litert_interpreter(str(tflite_path))
-        input_details = interpreter.get_input_details()
-        output_details = interpreter.get_output_details()
-        
-        interpreter.set_tensor(input_details[0]['index'], input_q)
-        interpreter.invoke()
-        output_data = interpreter.get_tensor(output_details[0]['index'])
-        output_data = np.array(output_data)
-        
-        # Convert output_data to the expected dtype before formatting.
-        if kernel_info["output_c_type"] == "int32_t":
-            output_data = output_data.astype(np.int32)
-        elif kernel_info["output_c_type"] == "int16_t":
-            output_data = output_data.astype(np.int16)
-        else:  # int8_t
-            output_data = output_data.astype(np.int8)
+
+        if kernel_info["input_c_type"] == "float16_t":
+            end_resolved = list(end) if end is not None else list(input_shape)
+            while len(end_resolved) < len(input_shape):
+                end_resolved.append(input_shape[len(end_resolved)])
+            slices = tuple(
+                slice(begin_normalized[i], end_resolved[i], strides[i])
+                for i in range(len(input_shape))
+            )
+            output_data = input_q[slices]
+            if shrink_axis_mask:
+                squeeze_axes = tuple(
+                    i for i in range(len(input_shape)) if shrink_axis_mask & (1 << i)
+                )
+                output_data = np.squeeze(output_data, axis=squeeze_axes)
+            output_data = np.array(output_data).astype(np.float16)
+        else:
+            # Run inference using LiteRT interpreter
+            interpreter = self.load_litert_interpreter(str(tflite_path))
+            input_details = interpreter.get_input_details()
+            output_details = interpreter.get_output_details()
+
+            interpreter.set_tensor(input_details[0]['index'], input_q)
+            interpreter.invoke()
+            output_data = interpreter.get_tensor(output_details[0]['index'])
+            output_data = np.array(output_data)
+
+            # Convert output_data to the expected dtype before formatting.
+            if kernel_info["output_c_type"] == "int32_t":
+                output_data = output_data.astype(np.int32)
+            elif kernel_info["output_c_type"] == "int16_t":
+                output_data = output_data.astype(np.int16)
+            else:  # int8_t
+                output_data = output_data.astype(np.int8)
         
         # Format arrays
         input_array_str = builder.format_array_as_c_literal(input_q)
@@ -293,6 +350,8 @@ class OpStridedSlice(OperationBase):
             'output_dtype': kernel_info["output_c_type"],
             'kernel_fn': kernel_info["kernel_fn"],
         }
+        if kernel_info["input_c_type"] == "float16_t":
+            context["validation_mode"] = "float"
         
         # Render templates
         includes_api_dir = output_dir / "includes"

--- a/helia_core_tester/generation/ops/catalog.py
+++ b/helia_core_tester/generation/ops/catalog.py
@@ -110,7 +110,14 @@ OPERATOR_SPECS: Dict[str, OperatorSpec] = {
         descriptor_relpaths=("BasicMathFunctions/add.yaml", "BasicMathFunctions/add_float.yaml"),
         template_relpath="BasicMathFunctions/add",
     ),
-    "Sub": _spec("Sub", "BasicMathFunctions", "sub", "OpSub", "BasicMathFunctions/sub.yaml", "BasicMathFunctions/sub"),
+    "Sub": _spec(
+        "Sub",
+        "BasicMathFunctions",
+        "sub",
+        "OpSub",
+        descriptor_relpaths=("BasicMathFunctions/sub.yaml", "BasicMathFunctions/sub_float.yaml"),
+        template_relpath="BasicMathFunctions/sub",
+    ),
     "Mul": _spec(
         "Mul",
         "BasicMathFunctions",
@@ -151,7 +158,14 @@ OPERATOR_SPECS: Dict[str, OperatorSpec] = {
         descriptor_relpaths=("ConcatenationFunctions/concatenation.yaml", "ConcatenationFunctions/concatenation_float.yaml"),
         template_relpath="ConcatenationFunctions/concatenation",
     ),
-    "Split": _spec("Split", "ConcatenationFunctions", "split", "OpSplit", "ConcatenationFunctions/split.yaml", "ConcatenationFunctions/split"),
+    "Split": _spec(
+        "Split",
+        "ConcatenationFunctions",
+        "split",
+        "OpSplit",
+        descriptor_relpaths=("ConcatenationFunctions/split.yaml", "ConcatenationFunctions/split_float.yaml"),
+        template_relpath="ConcatenationFunctions/split",
+    ),
     "Convolve": _spec(
         "Convolve",
         "ConvolutionFunctions",
@@ -288,7 +302,14 @@ OPERATOR_SPECS: Dict[str, OperatorSpec] = {
         descriptor_relpaths=("SoftmaxFunctions/softmax.yaml", "SoftmaxFunctions/softmax_float.yaml"),
         template_relpath="SoftmaxFunctions/softmax",
     ),
-    "StridedSlice": _spec("StridedSlice", "StridedSliceFunctions", "strided_slice", "OpStridedSlice", "StridedSliceFunctions/strided_slice.yaml", "StridedSliceFunctions/strided_slice"),
+    "StridedSlice": _spec(
+        "StridedSlice",
+        "StridedSliceFunctions",
+        "strided_slice",
+        "OpStridedSlice",
+        descriptor_relpaths=("StridedSliceFunctions/strided_slice.yaml", "StridedSliceFunctions/strided_slice_float.yaml"),
+        template_relpath="StridedSliceFunctions/strided_slice",
+    ),
     "Transpose": _spec(
         "Transpose",
         "TransposeFunctions",

--- a/helia_core_tester/generation/utils/litert_builder.py
+++ b/helia_core_tester/generation/utils/litert_builder.py
@@ -1577,6 +1577,98 @@ def build_split_op(
     return builder.build()
 
 
+def build_strided_slice_op(
+    *,
+    input_shape: Iterable[int],
+    begin: Sequence[int],
+    end: Sequence[int],
+    strides: Sequence[int],
+    shrink_axis_mask: int = 0,
+    dtype: str = "int8",
+) -> bytes:
+    """Build a single-op STRIDED_SLICE model, mainly to unlock float (FP16)
+    dtypes not reachable via the Keras/TFLiteConverter path used for the
+    quantized variants. Output shape is derived directly from Python slicing
+    semantics rather than TF's op resolver, so masks other than
+    ``shrink_axis_mask`` are intentionally unsupported.
+    """
+    if not LITERT_AVAILABLE:
+        raise ImportError("ai_edge_litert is not available. Install it with: pip install ai-edge-litert")
+
+    tensor_type = _DTYPE_MAP.get(dtype.lower())
+    if tensor_type is None:
+        raise ValueError(f"Unsupported dtype '{dtype}'.")
+
+    input_shape = tuple(int(dim) for dim in input_shape)
+    rank = len(input_shape)
+    begin = [int(v) for v in begin]
+    end = [int(v) for v in end]
+    strides = [int(v) for v in strides]
+    if not (len(begin) == len(end) == len(strides) == rank):
+        raise ValueError("begin/end/strides must match input rank.")
+
+    output_shape = []
+    for i in range(rank):
+        dim = input_shape[i]
+        if shrink_axis_mask & (1 << i):
+            output_shape.append(1)
+        else:
+            output_shape.append(len(range(dim)[begin[i]:end[i]:strides[i]]))
+
+    kept_axes = [i for i in range(rank) if not (shrink_axis_mask & (1 << i))]
+    squeezed_output_shape = tuple(output_shape[i] for i in kept_axes) or (1,)
+
+    builder = LiteRtSingleOpBuilder(op_name="STRIDED_SLICE")
+
+    input_tensor_idx = builder.add_tensor(
+        TensorSpec(
+            name="input",
+            shape=input_shape,
+            tensor_type=tensor_type,
+            is_input=True,
+            quantization=_default_quant(tensor_type),
+        )
+    )
+
+    begin_tensor_idx = builder.add_tensor(
+        TensorSpec(name="begin", shape=(rank,), tensor_type=litert.TensorType.INT32, data=begin)
+    )
+    end_tensor_idx = builder.add_tensor(
+        TensorSpec(name="end", shape=(rank,), tensor_type=litert.TensorType.INT32, data=end)
+    )
+    strides_tensor_idx = builder.add_tensor(
+        TensorSpec(name="strides", shape=(rank,), tensor_type=litert.TensorType.INT32, data=strides)
+    )
+
+    output_tensor_idx = builder.add_tensor(
+        TensorSpec(
+            name="output",
+            shape=squeezed_output_shape,
+            tensor_type=tensor_type,
+            is_output=True,
+            quantization=_default_quant(tensor_type),
+        )
+    )
+
+    options = litert.StridedSliceOptionsT()
+    options.beginMask = 0
+    options.endMask = 0
+    options.ellipsisMask = 0
+    options.newAxisMask = 0
+    options.shrinkAxisMask = int(shrink_axis_mask)
+    options.offset = False
+
+    builder.add_operator(
+        "STRIDED_SLICE",
+        inputs=[input_tensor_idx, begin_tensor_idx, end_tensor_idx, strides_tensor_idx],
+        outputs=[output_tensor_idx],
+        options=options,
+        options_type=litert.BuiltinOptions.StridedSliceOptions,
+    )
+
+    return builder.build()
+
+
 def build_prelu_op(
     *,
     input_shape: Iterable[int],


### PR DESCRIPTION
## Summary
ns-cmsis-nn PR [#215](https://github.com/AmbiqAI/ns-cmsis-nn/pull/215) adds three new float16 kernels for an unrolled GRU float16 path: `arm_split_f16`, `arm_strided_slice_f16`, and `arm_elementwise_sub_f16`. This PR extends the Sub/Split/StridedSlice test generators to support FP16, mirroring the existing Add FP16 pattern.

## Changes
- `litert_builder.py`: new `build_strided_slice_op` (LiteRT-only single-op builder) — Keras/TFLiteConverter has no reliable FP16 activation path for StridedSlice.
- `sub.py` / `sub.c.j2`: FP16 kernel selection (`arm_elementwise_sub_f16`) + float data-generation path (mirrors `add.py`).
- `split.py`: FP16 kernel selection (`arm_split_f16`) + float array generation (pure data movement, no quantization).
- `strided_slice.py`: FP16 kernel selection (`arm_strided_slice_f16`); FP16 descriptors bypass Keras and use the new LiteRT-only builder, with golden output computed directly via numpy slicing.
- `catalog.py`: register the new `*_float.yaml` descriptor files for Sub, Split, and StridedSlice — previously only a single descriptor file was wired up per operator, so new float descriptors were silently dropped from generation.
- New descriptors:
  - `assets/descriptors/BasicMathFunctions/sub_float.yaml` (3 cases)
  - `assets/descriptors/ConcatenationFunctions/split_float.yaml` (3 cases)
  - `assets/descriptors/StridedSliceFunctions/strided_slice_float.yaml` (5 cases, covering all 5 code-path branches in `arm_strided_slice_f16`: whole-slab, per-batch, per-row, per-pixel, general negative-stride)

## Testing
Ran against the ns-cmsis-nn `feat/gru-unrolled-f16-kernels` branch (PR #215) inside the CI container:

```
uv run helia_core_tester full --cpu cortex-m55 --suite float --float-precision f16 --coverage --run-jobs 0 --no-fail-fast
```
- 317/317 float tests pass (11 new, all PASS).
- Coverage (cortex-m55, float suite): `arm_split_f16.c` 100%, `arm_strided_slice_f16.c` 100%, `arm_elementwise_sub_f16.c` 85.71% (only uncovered line is the defensive argument-validation early return).
- FP16 execution is cortex-m55-only in this framework (MVE-FP16 required) — confirmed `--cpu cortex-m4 --float-precision f16` is rejected by config validation, so no other CPU targets apply for these kernels.

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli)
