### PR TITLE
fix: sub row scalar channel broadcast regression

### DIFF
--- a/assets/descriptors/ActivationFunctions/prelu.yaml
+++ b/assets/descriptors/ActivationFunctions/prelu.yaml
@@ -288,3 +288,27 @@ alpha_shape: [1, 2, 2, 3]
 output_shape: [1, 2, 2, 2]
 alpha: 0.2
 expected_status: ARM_CMSIS_NN_ARG_ERROR
+---
+operator: PReLU
+name: prelu_row_scalar_channel_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+  extras:
+    alpha_values: [-0.9, 0.0, 0.9]
+input_shape: [1, 3, 1, 4]
+alpha_shape: [1, 3, 1, 1]
+---
+operator: PReLU
+name: prelu_row_scalar_channel_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+  extras:
+    alpha_values: [-0.9, 0.0, 0.9]
+input_shape: [1, 3, 1, 4]
+alpha_shape: [1, 3, 1, 1]

--- a/assets/descriptors/BasicMathFunctions/mul.yaml
+++ b/assets/descriptors/BasicMathFunctions/mul.yaml
@@ -227,3 +227,43 @@ hint:
   call_style: per_tensor
 input_1_shape: [1, 2, 3, 4]
 input_2_shape: [1, 2, 1, 1]
+---
+operator: Mul
+name: mul_row_scalar_channel_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 1]
+input_2_shape: [1, 3, 1, 4]
+---
+operator: Mul
+name: mul_row_scalar_channel_reverse_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 4]
+input_2_shape: [1, 3, 1, 1]
+---
+operator: Mul
+name: mul_row_scalar_channel_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 1]
+input_2_shape: [1, 3, 1, 4]
+---
+operator: Mul
+name: mul_row_scalar_channel_reverse_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 4]
+input_2_shape: [1, 3, 1, 1]

--- a/assets/descriptors/BasicMathFunctions/squared_difference.yaml
+++ b/assets/descriptors/BasicMathFunctions/squared_difference.yaml
@@ -195,3 +195,31 @@ activation_dtype: S16
 weight_dtype: S8
 input_1_shape: [2, 2, 3, 4]
 input_2_shape: [1, 2, 3, 4]
+---
+name: squared_difference_row_scalar_channel_s8
+operator: SquaredDifference
+activation_dtype: S8
+weight_dtype: S8
+input_1_shape: [1, 3, 1, 1]
+input_2_shape: [1, 3, 1, 4]
+---
+name: squared_difference_row_scalar_channel_reverse_s8
+operator: SquaredDifference
+activation_dtype: S8
+weight_dtype: S8
+input_1_shape: [1, 3, 1, 4]
+input_2_shape: [1, 3, 1, 1]
+---
+name: squared_difference_row_scalar_channel_s16
+operator: SquaredDifference
+activation_dtype: S16
+weight_dtype: S8
+input_1_shape: [1, 3, 1, 1]
+input_2_shape: [1, 3, 1, 4]
+---
+name: squared_difference_row_scalar_channel_reverse_s16
+operator: SquaredDifference
+activation_dtype: S16
+weight_dtype: S8
+input_1_shape: [1, 3, 1, 4]
+input_2_shape: [1, 3, 1, 1]

--- a/assets/descriptors/BasicMathFunctions/sub.yaml
+++ b/assets/descriptors/BasicMathFunctions/sub.yaml
@@ -197,3 +197,43 @@ hint:
   call_style: per_tensor
 input_1_shape: [1, 2, 3, 4]
 input_2_shape: [1, 2, 1, 1]
+---
+operator: Sub
+name: sub_row_scalar_channel_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 1]
+input_2_shape: [1, 3, 1, 4]
+---
+operator: Sub
+name: sub_row_scalar_channel_reverse_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 4]
+input_2_shape: [1, 3, 1, 1]
+---
+operator: Sub
+name: sub_row_scalar_channel_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 1]
+input_2_shape: [1, 3, 1, 4]
+---
+operator: Sub
+name: sub_row_scalar_channel_reverse_s16
+activation_dtype: S16
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_1_shape: [1, 3, 1, 4]
+input_2_shape: [1, 3, 1, 1]

--- a/helia_core_tester/scripts/merge_lcov_inputs.py
+++ b/helia_core_tester/scripts/merge_lcov_inputs.py
@@ -1,0 +1,107 @@
+"""
+Merge multiple LCOV coverage.info files (e.g. per float-precision passes)
+into a single coverage.info by summing per-file/per-line hit counts.
+
+Used by CI to combine independent f32/f16 float coverage runs into one
+canonical coverage.info before handing it to `helia_core_tester coverage-merge`,
+which expects exactly one coverage.info per (suite, cpu) pair.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+def _parse_lcov(path: Path) -> Dict[str, Dict[int, int]]:
+    """Parse an LCOV file into {source_file: {line_no: hit_count}}."""
+    files: Dict[str, Dict[int, int]] = {}
+    current_file: str | None = None
+
+    for raw_line in path.read_text(errors="ignore").splitlines():
+        line = raw_line.strip()
+        if line.startswith("SF:"):
+            current_file = line[3:].strip()
+            files.setdefault(current_file, {})
+            continue
+        if not current_file:
+            continue
+        if line.startswith("DA:"):
+            payload = line[3:].split(",")
+            if len(payload) >= 2:
+                try:
+                    line_no = int(payload[0])
+                    hit_count = int(payload[1])
+                except ValueError:
+                    continue
+                lines = files[current_file]
+                lines[line_no] = lines.get(line_no, 0) + hit_count
+            continue
+
+    return files
+
+
+def merge_lcov_files(inputs: List[Path]) -> Dict[str, Dict[int, int]]:
+    merged: Dict[str, Dict[int, int]] = {}
+    for input_path in inputs:
+        if not input_path.exists():
+            continue
+        parsed = _parse_lcov(input_path)
+        for source_file, lines in parsed.items():
+            merged_lines = merged.setdefault(source_file, {})
+            for line_no, hit_count in lines.items():
+                merged_lines[line_no] = merged_lines.get(line_no, 0) + hit_count
+    return merged
+
+
+def _write_lcov(merged: Dict[str, Dict[int, int]], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    lines: List[str] = []
+    for source_file in sorted(merged.keys()):
+        line_hits = merged[source_file]
+        lines.append(f"SF:{source_file}")
+        for line_no in sorted(line_hits.keys()):
+            lines.append(f"DA:{line_no},{line_hits[line_no]}")
+        lh = sum(1 for count in line_hits.values() if count > 0)
+        lf = len(line_hits)
+        lines.append(f"LH:{lh}")
+        lines.append(f"LF:{lf}")
+        lines.append("end_of_record")
+    out_path.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Merge multiple LCOV coverage.info files by summing per-line hit counts."
+    )
+    parser.add_argument(
+        "--input",
+        action="append",
+        required=True,
+        dest="inputs",
+        help="Path to an input coverage.info file. May be passed multiple times. Missing paths are skipped.",
+    )
+    parser.add_argument("--output", required=True, type=Path, help="Path to write the merged coverage.info")
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    input_paths = [Path(item) for item in args.inputs]
+    existing = [path for path in input_paths if path.exists()]
+    if not existing:
+        print(f"error: none of the requested input coverage.info files exist: {input_paths}", file=sys.stderr)
+        return 1
+
+    merged = merge_lcov_files(existing)
+    _write_lcov(merged, args.output)
+    print(f"Merged {len(existing)}/{len(input_paths)} input(s) -> {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This pull request introduces comprehensive regression tests for broadcast pointer bugs in several math and activation operators, and adds a new utility script for merging LCOV coverage reports. The tests are designed to catch subtle issues in pointer advancement logic when broadcasting over rows and channels, matching bugs previously fixed in related operators. The new script streamlines CI coverage reporting by merging multiple coverage files.

**Regression tests for broadcast pointer bugs:**

* Added new test cases in `mul.yaml`, `sub.yaml`, and `squared_difference.yaml` for S8 and S16 variants of Mul, Sub, and SquaredDifference operators. These tests specifically target bugs where row-scalar inputs with non-broadcasted height could cause incorrect pointer advancement, ensuring per-row values are handled correctly. Reverse operand cases are also included for completeness. [[1]](diffhunk://#diff-ee32508cbd687aaede84831dbc5a1f5779105918afda356ce01ff268e9b5cc84R230-R279) [[2]](diffhunk://#diff-7af1f8db22d6be011d81cb204e46b8abce83ed43af2a611639234206bc5a2498R200-R249) [[3]](diffhunk://#diff-e066b240da5938d35f0fa2062d12861ad0b4f1854402d6d2abad56acd9a7c9a3R198-R235)
* Added similar regression tests in `prelu.yaml` for the PReLU operator, both S8 and S16, to verify correct handling of row-scalar alpha tensors with non-broadcasted height.

**CI and coverage tooling:**

* Introduced a new script `merge_lcov_inputs.py` in `helia_core_tester/scripts/` to merge multiple LCOV `coverage.info` files by summing per-file/per-line hit counts, facilitating combined coverage reporting in CI workflows.