### PR TITLE
feat: Add S4 convolve kernel_sum test variants for weight-sum DSP route

### DIFF
--- a/assets/templates/ConvolutionFunctions/convolve/convolve.c.j2
+++ b/assets/templates/ConvolutionFunctions/convolve/convolve.c.j2
@@ -10,8 +10,8 @@ static cmsis_nn_context {{ name }}_ctx;
 #define {{ name|upper }}_BUFFER_SIZE_MAX {{ buffer_size_max }}
 static uint8_t {{ name }}_buffer[{{ name|upper }}_BUFFER_SIZE_MAX];
 
-{% if kernel_fn == 'arm_convolve_wrapper_s8' %}
-// Weight sum context for s8 convolutions
+{% if kernel_fn == 'arm_convolve_wrapper_s8' or (kernel_fn == 'arm_convolve_wrapper_s4' and use_weight_sum) %}
+// Weight sum context (precomputed input-offset/bias fold, avoids per-MAC offset arithmetic)
 static cmsis_nn_context {{ name }}_weight_sum_ctx;
 // Weight sum buffer size: output channels * sizeof(int32_t)
 // CMSIS-NN uses output_dims->c, which should equal filter_dims.n (output channels)
@@ -136,6 +136,43 @@ int32_t {{ prefix }}_{{ name }}_run(
         output
     );
     {% elif kernel_fn == 'arm_convolve_wrapper_s4' %}
+    {% if use_weight_sum %}
+    // Initialize weight sum context and buffer
+    {{ name }}_weight_sum_ctx.buf = {{ name }}_weight_sum_buffer;
+    {{ name }}_weight_sum_ctx.size = {{ name|upper }}_WEIGHT_SUM_BUFFER_SIZE;
+
+    // Calculate weight sum (folds input_offset * sum(weights) + bias)
+    int32_t lhs_offset = (int32_t){{ name }}_conv_params.input_offset;
+    arm_convolve_weight_sum_s4((int32_t*){{ name }}_weight_sum_ctx.buf,
+                               {{ name }}_weights,
+                               &{{ name }}_input_dims,
+                               &{{ name }}_filter_dims,
+                               &{{ name }}_output_dims,
+                               lhs_offset,
+                               {% if has_biases %}{{ name }}_biases{% else %}NULL{% endif %});
+
+    // s4 weight-sum signature: (ctx, weight_sum_ctx, conv_params, quant_params, input_dims, input_data,
+    // filter_dims, filter_data, bias_dims, bias_data, output_dims, output_data)
+    return arm_convolve_wrapper_s4_with_weight_sum(
+        &{{ name }}_ctx,
+        &{{ name }}_weight_sum_ctx,
+        &{{ name }}_conv_params,
+        &{{ name }}_quant_params,
+        &{{ name }}_input_dims,
+        input,
+        &{{ name }}_filter_dims,
+        {{ name }}_weights,
+        {% if has_biases %}
+        &{{ name }}_bias_dims,
+        {{ name }}_biases,
+        {% else %}
+        NULL,  // bias_dims
+        NULL,  // bias_data
+        {% endif %}
+        &{{ name }}_output_dims,
+        output
+    );
+    {% else %}
     // s4 signature: (ctx, conv_params, quant_params, input_dims, input_data, filter_dims, filter_data, bias_dims, bias_data, output_dims, output_data)
     return arm_convolve_wrapper_s4(
         &{{ name }}_ctx,
@@ -155,6 +192,7 @@ int32_t {{ prefix }}_{{ name }}_run(
         &{{ name }}_output_dims,
         output
     );
+    {% endif %}
     {% elif kernel_fn == 'arm_convolve_wrapper_s16' %}
     // s16 signature: (ctx, conv_params, quant_params, input_dims, input_data, filter_dims, filter_data, bias_dims, bias_data, output_dims, output_data)
     // Note: s16 uses cmsis_nn_bias_data struct, not raw pointer (defined at file scope above)

--- a/helia_core_tester/generation/io/descriptors.py
+++ b/helia_core_tester/generation/io/descriptors.py
@@ -413,6 +413,45 @@ def expand_descriptor_variations(desc: Dict[str, Any]) -> List[Dict[str, Any]]:
     return expanded_descriptors
 
 
+# Operator + weight_dtype combos that expose an opt-in precomputed weight-sum ("kernel_sum")
+# kernel route (ns-cmsis-nn `arm_*_with_weight_sum` entry points). Each eligible descriptor is
+# automatically duplicated into a `<name>_kernel_sum` variant (hint.kernel_sum = True) in
+# addition to the original default (non-weight-sum) descriptor, so both routes get covered
+# without hand-duplicating every YAML test case. Extend this set as later PRs land support
+# for more operator/dtype combos (e.g. depthwise conv s4/s8, conv/dwconv s16, fully connected).
+KERNEL_SUM_ELIGIBLE_COMBOS = {
+    ('Convolve', 'S4'),
+}
+
+
+def expand_kernel_sum_variant(desc: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Duplicate an eligible descriptor into the default (non-weight-sum) descriptor plus a
+    `_kernel_sum` sibling with hint.kernel_sum = True, so generation exercises both the
+    plain and precomputed-weight-sum kernel routes for the same test shape/quantization.
+
+    Descriptors that already set hint.kernel_sum explicitly (e.g. a hand-authored
+    regression case) are left untouched and not duplicated.
+    """
+    operator = desc.get('operator')
+    weight_dtype = str(desc.get('weight_dtype', 'S8')).upper()
+    if (operator, weight_dtype) not in KERNEL_SUM_ELIGIBLE_COMBOS:
+        return [desc]
+
+    hint = desc.get('hint') or {}
+    if hint.get('kernel_sum') is not None:
+        return [desc]
+
+    kernel_sum_desc = copy.deepcopy(desc)
+    kernel_sum_desc['name'] = f"{desc['name']}_kernel_sum"
+    kernel_sum_hint = dict(kernel_sum_desc.get('hint') or {})
+    kernel_sum_hint['kernel_sum'] = True
+    kernel_sum_desc['hint'] = kernel_sum_hint
+    kernel_sum_desc['_base_name'] = desc.get('_base_name', desc['name'])
+
+    return [desc, kernel_sum_desc]
+
+
 def load_all_descriptors(descriptors_dir: str) -> List[Dict[str, Any]]:
     """
     Load and validate all descriptors in directory.
@@ -452,7 +491,8 @@ def load_all_descriptors(descriptors_dir: str) -> List[Dict[str, Any]]:
                     # If name exists, keep it as-is (preserve original meaningful names)
                     
                     expanded_descs = expand_descriptor_variations(desc_copy)
-                    descriptors.extend(expanded_descs)
+                    for expanded in expanded_descs:
+                        descriptors.extend(expand_kernel_sum_variant(expanded))
             else:
                 # Single descriptor - preserve original name if present
                 for desc in descs:
@@ -463,7 +503,8 @@ def load_all_descriptors(descriptors_dir: str) -> List[Dict[str, Any]]:
                     # Otherwise, keep the original name
                     
                     expanded_descs = expand_descriptor_variations(desc)
-                    descriptors.extend(expanded_descs)
+                    for expanded in expanded_descs:
+                        descriptors.extend(expand_kernel_sum_variant(expanded))
         except Exception as e:
             print(f"Warning: Failed to load descriptor {desc_path}: {e}")
             continue

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
@@ -210,6 +210,13 @@ class OpConvolve(OperationBase):
         info.setdefault("buffer_size_needs_layout", info["input_c_type"] in {"float", "float16_t"})
 
         hint = self._hint()
+
+        # Opt-in precomputed weight-sum (kernel_sum) route. Currently only the s4 conv
+        # wrapper has a distinct `_with_weight_sum` entry point; s8 already always runs
+        # through its weight-sum-aware wrapper (see convolve.c.j2).
+        if info["kernel_fn"] == "arm_convolve_wrapper_s4":
+            info["use_weight_sum"] = bool(hint.get("kernel_sum", False))
+
         variant = str(hint.get("kernel_variant", "")).lower()
         if not variant:
             return info
@@ -584,6 +591,7 @@ class OpConvolve(OperationBase):
                 else ('cmsis_nn_conv_params_f32' if float_kernel else 'cmsis_nn_conv_params')
             ),
             'kernel_layout': kernel_info.get("layout", "ARM_NN_LAYOUT_NHWC"),
+            'use_weight_sum': bool(kernel_info.get("use_weight_sum", False)),
         }
         if float_kernel:
             context['conv_activation_min_literal'] = builder.format_float_literal(conv_params['activation_min'])


### PR DESCRIPTION
Adds test coverage for ns-cmsis-nn PR #208 (`arm_convolve_wrapper_s4_with_weight_sum` DSP route).

- `descriptors.py`: `KERNEL_SUM_ELIGIBLE_COMBOS` + `expand_kernel_sum_variant()` auto-duplicates eligible descriptors into a `<name>_kernel_sum` sibling (currently scoped to `(Convolve, S4)`; extensible for #209-#212).
- `convolve.py`: threads `use_weight_sum` through `_select_cmsis_convolve_kernel` for `arm_convolve_wrapper_s4`, driven by `hint.kernel_sum`.
- `convolve.c.j2`: splits the s4 call branch into with/without weight-sum paths; kernel_sum variant precomputes via `arm_convolve_weight_sum_s4()` then calls `arm_convolve_wrapper_s4_with_weight_sum()`.

Validated: 25 S4 convolve descriptors -> 50 total (25 default + 25 `_kernel_sum`), all unique. Generated, built, and ran all 50 on cortex-m4 (DSP/non-MVE) against Corstone-300 FVP: **50/50 passed**.