### PR TITLE
feat: add FP32/FP16 coverage for abs, sub, prelu, and strided_slice

### DIFF
--- a/assets/descriptors/ActivationFunctions/prelu_float.yaml
+++ b/assets/descriptors/ActivationFunctions/prelu_float.yaml
@@ -53,3 +53,26 @@ tensor_dtypes:
 input_shape: [1, 3, 4, 5]
 alpha_shape: [1]
 alpha: 0.25
+---
+operator: PReLU
+name: prelu_float_broadcast_hw_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+# Alpha broadcasts over H (1 vs input's 3) while matching N, W, and C
+# exactly. This is neither identical-shape, scalar, nor pure per-channel
+# (1,1,1,C), so it exercises the general N/H/W/C broadcast walk in
+# arm_prelu_f32/f16.
+input_shape: [1, 3, 4, 5]
+alpha_shape: [1, 1, 4, 5]
+---
+operator: PReLU
+name: prelu_float_broadcast_hw_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+# See prelu_float_broadcast_hw_f32: exercises the general broadcast walk.
+input_shape: [1, 3, 4, 5]
+alpha_shape: [1, 1, 4, 5]

--- a/assets/descriptors/ActivationFunctions/prelu_float.yaml
+++ b/assets/descriptors/ActivationFunctions/prelu_float.yaml
@@ -1,0 +1,55 @@
+operator: PReLU
+name: prelu_float_per_channel_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape: [1, 3, 4, 5]
+alpha_shape: [5]
+---
+operator: PReLU
+name: prelu_float_full_alpha_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape: [1, 3, 4, 5]
+alpha_shape: [3, 4, 5]
+---
+operator: PReLU
+name: prelu_float_scalar_alpha_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape: [1, 3, 4, 5]
+alpha_shape: [1]
+alpha: 0.25
+---
+operator: PReLU
+name: prelu_float_per_channel_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape: [1, 3, 4, 5]
+alpha_shape: [5]
+---
+operator: PReLU
+name: prelu_float_full_alpha_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape: [1, 3, 4, 5]
+alpha_shape: [3, 4, 5]
+---
+operator: PReLU
+name: prelu_float_scalar_alpha_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape: [1, 3, 4, 5]
+alpha_shape: [1]
+alpha: 0.25

--- a/assets/descriptors/BasicMathFunctions/abs_float.yaml
+++ b/assets/descriptors/BasicMathFunctions/abs_float.yaml
@@ -1,0 +1,31 @@
+operator: Abs
+name: abs_float_default_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape: [1, 4, 4, 8]
+---
+operator: Abs
+name: abs_float_tail_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape: [1, 1, 1, 5]
+---
+operator: Abs
+name: abs_float_default_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape: [1, 4, 4, 8]
+---
+operator: Abs
+name: abs_float_tail_f16
+suite: float
+tensor_dtypes:
+  input: FP16
+  output: FP16
+input_shape: [1, 1, 1, 9]

--- a/assets/descriptors/BasicMathFunctions/sub_float.yaml
+++ b/assets/descriptors/BasicMathFunctions/sub_float.yaml
@@ -24,3 +24,30 @@ tensor_dtypes:
   output: FP16
 input_1_shape: [1, 3, 5, 3]
 input_2_shape: [1, 3, 5, 3]
+---
+operator: Sub
+name: sub_float_default_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_1_shape: [1, 4, 4, 8]
+input_2_shape: [1, 4, 4, 8]
+---
+operator: Sub
+name: sub_float_tail_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_1_shape: [1, 1, 1, 5]
+input_2_shape: [1, 1, 1, 5]
+---
+operator: Sub
+name: sub_float_odd_block_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_1_shape: [1, 3, 4, 5]
+input_2_shape: [1, 3, 4, 5]

--- a/assets/descriptors/StridedSliceFunctions/strided_slice_float.yaml
+++ b/assets/descriptors/StridedSliceFunctions/strided_slice_float.yaml
@@ -132,3 +132,138 @@ strides:
 - -1
 - -1
 - -2
+---
+operator: StridedSlice
+name: strided_slice_float_whole_slab_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape:
+- 2
+- 3
+- 4
+- 2
+begin:
+- 1
+- 0
+- 0
+- 0
+end:
+- 2
+- 3
+- 4
+- 2
+strides:
+- 1
+- 1
+- 1
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_batch_slice_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape:
+- 3
+- 4
+- 3
+- 2
+begin:
+- 0
+- 1
+- 0
+- 0
+end:
+- 3
+- 3
+- 3
+- 2
+strides:
+- 2
+- 1
+- 1
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_crop_width_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape:
+- 1
+- 3
+- 4
+- 2
+begin:
+- 0
+- 0
+- 0
+- 0
+end:
+- 1
+- 3
+- 2
+- 2
+strides:
+- 1
+- 1
+- 1
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_stride2_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape:
+- 1
+- 3
+- 4
+- 2
+begin:
+- 0
+- 0
+- 0
+- 0
+end:
+- 1
+- 3
+- 4
+- 2
+strides:
+- 1
+- 1
+- 2
+- 1
+---
+operator: StridedSlice
+name: strided_slice_float_general_neg_stride_f32
+suite: float
+tensor_dtypes:
+  input: FP32
+  output: FP32
+input_shape:
+- 1
+- 3
+- 4
+- 4
+begin:
+- 0
+- 2
+- 3
+- 3
+end:
+- 1
+- 0
+- 0
+- 0
+strides:
+- 1
+- -1
+- -1
+- -2

--- a/assets/templates/ActivationFunctions/prelu/prelu.c.j2
+++ b/assets/templates/ActivationFunctions/prelu/prelu.c.j2
@@ -10,6 +10,16 @@ int32_t {{ prefix }}_{{ name }}_run(
     {{ output_dtype }}* __restrict output
 ) {
     // Call PReLU kernel
+    {% if float_kernel %}
+    arm_cmsis_nn_status kernel_status = {{ kernel_fn }}(
+        &{{ name }}_input_dims,
+        input,
+        &{{ name }}_alpha_dims,
+        {{ name }}_alpha,
+        &{{ name }}_output_dims,
+        output
+    );
+    {% else %}
     arm_cmsis_nn_status kernel_status = {{ kernel_fn }}(
         &{{ name }}_input_dims,
         input,
@@ -25,6 +35,7 @@ int32_t {{ prefix }}_{{ name }}_run(
         &{{ name }}_output_dims,
         output
     );
+    {% endif %}
     
     return kernel_status;
 }

--- a/assets/templates/BasicMathFunctions/abs/abs.c.j2
+++ b/assets/templates/BasicMathFunctions/abs/abs.c.j2
@@ -10,6 +10,13 @@ int32_t {{ prefix }}_{{ name }}_run(
     {{ output_dtype }}* __restrict output
 ) {
     // Call abs kernel
+    {% if float_kernel %}
+    arm_cmsis_nn_status kernel_status = {{ kernel_fn }}(
+        input,
+        output,
+        {{ block_size }}           // block_size
+    );
+    {% else %}
     arm_cmsis_nn_status kernel_status = {{ kernel_fn }}(
         input,
         {{ input_offset }},        // input_offset (negated zero point)
@@ -22,6 +29,7 @@ int32_t {{ prefix }}_{{ name }}_run(
         {{ out_activation_max }},  // out_activation_max
         {{ block_size }}           // block_size
     );
+    {% endif %}
 
     return kernel_status;
 }

--- a/helia_core_tester/generation/ops/ActivationFunctions/prelu.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/prelu.py
@@ -92,9 +92,9 @@ class OpPReLU(OperationBase):
         from helia_core_tester.generation.utils.litert_builder import build_prelu_op
 
         activation_dtype = self.desc.get("activation_dtype", "S8")
-        dtype_map = {"S8": "int8", "S16": "int16"}
+        dtype_map = {"S8": "int8", "S16": "int16", "FP32": "float32", "FP16": "float16"}
         if activation_dtype not in dtype_map:
-            raise NotImplementedError(f"Unsupported PReLU dtype: {activation_dtype} (only S8/S16 supported)")
+            raise NotImplementedError(f"Unsupported PReLU dtype: {activation_dtype}")
         litert_dtype = dtype_map[activation_dtype]
 
         input_shape = tuple(self.desc["input_shape"])
@@ -102,23 +102,7 @@ class OpPReLU(OperationBase):
         self._validate_broadcast_support(input_shape, alpha_shape)
 
         # Get alpha values from descriptor
-        alpha_values = None
-        if "alpha" in self.desc:
-            alpha_scalar = self.desc["alpha"]
-            if isinstance(alpha_scalar, (int, float)):
-                alpha_values = [float(alpha_scalar)]
-            elif isinstance(alpha_scalar, list):
-                alpha_values = alpha_scalar
-
-        if alpha_values is None and "hint" in self.desc:
-            extras = self.desc.get("hint", {}).get("extras", {})
-            if "alpha_values" in extras:
-                alpha_list = extras["alpha_values"]
-                if isinstance(alpha_list, list) and len(alpha_list) > 0:
-                    if isinstance(alpha_list[0], list):
-                        alpha_values = [item for sublist in alpha_list for item in sublist]
-                    else:
-                        alpha_values = alpha_list
+        alpha_values = self._descriptor_alpha_values()
 
         # Ensure alpha values match alpha_shape
         _ = self._prepare_alpha_values(tuple(alpha_shape), alpha_values)
@@ -145,13 +129,29 @@ class OpPReLU(OperationBase):
             return {
                 'kernel_fn': 'arm_prelu_s8',
                 'input_c_type': 'int8_t',
-                'output_c_type': 'int8_t'
+                'output_c_type': 'int8_t',
+                'float_kernel': False,
             }
         elif activation_dtype == 'S16':
             return {
                 'kernel_fn': 'arm_prelu_s16',
                 'input_c_type': 'int16_t',
-                'output_c_type': 'int16_t'
+                'output_c_type': 'int16_t',
+                'float_kernel': False,
+            }
+        elif activation_dtype == 'FP32':
+            return {
+                'kernel_fn': 'arm_prelu_f32',
+                'input_c_type': 'float',
+                'output_c_type': 'float',
+                'float_kernel': True,
+            }
+        elif activation_dtype == 'FP16':
+            return {
+                'kernel_fn': 'arm_prelu_f16',
+                'input_c_type': 'float16_t',
+                'output_c_type': 'float16_t',
+                'float_kernel': True,
             }
         else:
             raise NotImplementedError(f"Unsupported PReLU dtype: {activation_dtype} (only S8/S16 supported)")
@@ -280,12 +280,110 @@ class OpPReLU(OperationBase):
         out = np.clip(out, -32768, 32767).astype(np.int16)
         return out
 
+    def _descriptor_alpha_values(self):
+        """Alpha values as authored in the descriptor, or None for the default ramp."""
+        alpha_values = None
+        if "alpha" in self.desc:
+            alpha_scalar = self.desc["alpha"]
+            if isinstance(alpha_scalar, (int, float)):
+                alpha_values = [float(alpha_scalar)]
+            elif isinstance(alpha_scalar, list):
+                alpha_values = alpha_scalar
+        if alpha_values is None and "hint" in self.desc:
+            extras = self.desc.get("hint", {}).get("extras", {})
+            if "alpha_values" in extras:
+                alpha_list = extras["alpha_values"]
+                if isinstance(alpha_list, list) and len(alpha_list) > 0:
+                    if isinstance(alpha_list[0], list):
+                        alpha_values = [item for sublist in alpha_list for item in sublist]
+                    else:
+                        alpha_values = alpha_list
+        return alpha_values
+
+    def _generate_float_c_files(self, output_dir: Path, kernel_info: Dict[str, str]) -> None:
+        """
+        Generate C and H files for the float PReLU kernels.
+
+        arm_prelu_f32/f16 take (input_dims, input, alpha_dims, alpha,
+        output_dims, output) with no quantization parameters; alpha and the
+        golden output are derived from the descriptor with numpy (PReLU is
+        exact in the working precision, so no interpreter is needed).
+        """
+        from helia_core_tester.generation.utils.template_context import TemplateContextBuilder
+
+        name = self.desc['name']
+        float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
+
+        input_shape = tuple(self.desc["input_shape"])
+        alpha_shape = self._resolved_alpha_shape()
+        alpha = self._prepare_alpha_values(alpha_shape, self._descriptor_alpha_values()).astype(float_dtype)
+
+        builder = TemplateContextBuilder()
+        input_dims = builder.nhwc_to_cmsis_dims(input_shape)
+        output_dims = builder.nhwc_to_cmsis_dims(input_shape)
+        if len(alpha_shape) == 1:
+            alpha_dims = {'n': 1, 'h': 1, 'w': 1, 'c': int(alpha_shape[0])}
+        else:
+            alpha_dims = builder.nhwc_to_cmsis_dims(alpha_shape)
+
+        rng_state = self.rng.__getstate__()
+        self.rng = np.random.default_rng(self.seed)
+        input_q = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(float_dtype)
+        self.rng.__setstate__(rng_state)
+
+        alpha_bc = alpha.reshape(
+            (alpha_dims['n'], alpha_dims['h'], alpha_dims['w'], alpha_dims['c'])
+        )
+        output_data = np.where(input_q >= 0, input_q, input_q * alpha_bc).astype(float_dtype)
+
+        context = {
+            'name': name,
+            'prefix': name,
+            'input_dims': input_dims,
+            'alpha_dims': alpha_dims,
+            'output_dims': output_dims,
+            'input_offset': 0,
+            'alpha_offset': 0,
+            'output_offset': 0,
+            'output_mult_alpha': 0,
+            'output_shift_alpha': 0,
+            'output_mult_identity': 0,
+            'output_shift_identity': 0,
+            'input_data_array': builder.format_array_as_c_literal(input_q),
+            'alpha_array': builder.format_array_as_c_literal(alpha),
+            'expected_output_array': builder.format_array_as_c_literal(output_data),
+            'input_dtype': kernel_info["input_c_type"],
+            'output_dtype': kernel_info["output_c_type"],
+            'alpha_dtype': kernel_info["input_c_type"],
+            'kernel_fn': kernel_info["kernel_fn"],
+            'float_kernel': True,
+            'validation_mode': 'float',
+        }
+        cmake_context = {
+            'name': name,
+            'operator': self.desc.get('operator', 'PReLU'),
+            'operator_name': 'prelu',
+        }
+        self._write_op_outputs(
+            output_dir,
+            "prelu",
+            "ActivationFunctions/prelu/prelu.h.j2",
+            "ActivationFunctions/prelu/prelu.c.j2",
+            context,
+            cmake_context,
+        )
+
     def generate_c_files(self, output_dir: Path) -> None:
         """
         Generate C and H files from templates for PReLU operation.
         """
         if self._is_arg_error_case():
             self._generate_arg_error_c_files(output_dir)
+            return
+
+        float_kernel_info = self._select_cmsis_prelu_kernel()
+        if float_kernel_info.get('float_kernel'):
+            self._generate_float_c_files(output_dir, float_kernel_info)
             return
 
         from helia_core_tester.generation.utils.template_context import TemplateContextBuilder

--- a/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
@@ -38,6 +38,10 @@ class OpAbs(OperationBase):
             dtype = "int8"
         elif activation_dtype == "S16":
             dtype = "int16"
+        elif activation_dtype == "FP32":
+            dtype = "float32"
+        elif activation_dtype == "FP16":
+            dtype = "float16"
         else:
             raise NotImplementedError(f"Unsupported Abs dtype: {activation_dtype}")
 
@@ -53,12 +57,28 @@ class OpAbs(OperationBase):
                 "kernel_fn": "arm_abs_s8",
                 "input_c_type": "int8_t",
                 "output_c_type": "int8_t",
+                "float_kernel": False,
             }
         if activation_dtype == "S16":
             return {
                 "kernel_fn": "arm_abs_s16",
                 "input_c_type": "int16_t",
                 "output_c_type": "int16_t",
+                "float_kernel": False,
+            }
+        if activation_dtype == "FP32":
+            return {
+                "kernel_fn": "arm_abs_f32",
+                "input_c_type": "float",
+                "output_c_type": "float",
+                "float_kernel": True,
+            }
+        if activation_dtype == "FP16":
+            return {
+                "kernel_fn": "arm_abs_f16",
+                "input_c_type": "float16_t",
+                "output_c_type": "float16_t",
+                "float_kernel": True,
             }
         raise NotImplementedError(f"Unsupported Abs dtype: {activation_dtype}")
 
@@ -84,43 +104,56 @@ class OpAbs(OperationBase):
         input_shape = self._ensure_shape_tuple(op_tensors["inputs"][0]["shape"])
         output_shape = self._ensure_shape_tuple(op_tensors["outputs"][0]["shape"])
 
-        input_quant = op_tensors["inputs"][0]["quantization"]
-        output_quant = op_tensors["outputs"][0]["quantization"]
-
-        input_scale, input_zp = scalar_scale_zp(input_quant)
-        output_scale, output_zp = scalar_scale_zp(output_quant)
-
         builder = TemplateContextBuilder()
         input_dims = builder.nhwc_to_cmsis_dims(input_shape)
         output_dims = builder.nhwc_to_cmsis_dims(output_shape)
 
         activation_dtype = self.desc.get("activation_dtype", "S8")
-        activation_min, activation_max = activation_bounds(activation_dtype)
 
-        effective_scale = float(input_scale) / float(output_scale)
-        output_mult, output_shift = calculate_multiplier_shift(effective_scale)
-        needs_rescale = 0 if abs(effective_scale - 1.0) < 1e-6 else 1
-        if bool(self.desc.get("hint", {}).get("force_rescale", False)):
-            needs_rescale = 1
+        if kernel_info["float_kernel"]:
+            # arm_abs_f32/f16 are pure (input, output, block_size) kernels
+            # with no quantization or activation parameters.
+            float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
+            rng_state = self.rng.__getstate__()
+            self.rng = np.random.default_rng(self.seed)
+            input_q = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(float_dtype)
+            self.rng.__setstate__(rng_state)
+            output_data = np.abs(input_q).astype(float_dtype)
+            input_zp = output_zp = output_mult = output_shift = needs_rescale = 0
+            activation_min = activation_max = 0
+        else:
+            input_quant = op_tensors["inputs"][0]["quantization"]
+            output_quant = op_tensors["outputs"][0]["quantization"]
 
-        rng_state = self.rng.__getstate__()
-        self.rng = np.random.default_rng(self.seed)
-        input_data = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(np.float32)
-        self.rng.__setstate__(rng_state)
+            input_scale, input_zp = scalar_scale_zp(input_quant)
+            output_scale, output_zp = scalar_scale_zp(output_quant)
 
-        qmin, qmax = activation_bounds(activation_dtype)
-        np_in_dtype = np.int16 if activation_dtype == "S16" else np.int8
-        input_q = np.round(input_data / float(input_scale) + float(input_zp)).astype(np.int32)
-        input_q = np.clip(input_q, qmin, qmax).astype(np_in_dtype)
+            activation_min, activation_max = activation_bounds(activation_dtype)
 
-        interpreter = self.load_litert_interpreter(str(tflite_path))
-        input_details = interpreter.get_input_details()
-        output_details = interpreter.get_output_details()
+            effective_scale = float(input_scale) / float(output_scale)
+            output_mult, output_shift = calculate_multiplier_shift(effective_scale)
+            needs_rescale = 0 if abs(effective_scale - 1.0) < 1e-6 else 1
+            if bool(self.desc.get("hint", {}).get("force_rescale", False)):
+                needs_rescale = 1
 
-        interpreter.set_tensor(input_details[0]["index"], input_q)
-        interpreter.invoke()
-        output_data = interpreter.get_tensor(output_details[0]["index"])
-        output_data = np.array(output_data)
+            rng_state = self.rng.__getstate__()
+            self.rng = np.random.default_rng(self.seed)
+            input_data = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(np.float32)
+            self.rng.__setstate__(rng_state)
+
+            qmin, qmax = activation_bounds(activation_dtype)
+            np_in_dtype = np.int16 if activation_dtype == "S16" else np.int8
+            input_q = np.round(input_data / float(input_scale) + float(input_zp)).astype(np.int32)
+            input_q = np.clip(input_q, qmin, qmax).astype(np_in_dtype)
+
+            interpreter = self.load_litert_interpreter(str(tflite_path))
+            input_details = interpreter.get_input_details()
+            output_details = interpreter.get_output_details()
+
+            interpreter.set_tensor(input_details[0]["index"], input_q)
+            interpreter.invoke()
+            output_data = interpreter.get_tensor(output_details[0]["index"])
+            output_data = np.array(output_data)
 
         input_array_str = builder.format_array_as_c_literal(input_q)
         expected_output_array_str = builder.format_array_as_c_literal(output_data)
@@ -145,7 +178,10 @@ class OpAbs(OperationBase):
             "input_dtype": kernel_info["input_c_type"],
             "output_dtype": kernel_info["output_c_type"],
             "kernel_fn": kernel_info["kernel_fn"],
+            "float_kernel": kernel_info["float_kernel"],
         }
+        if kernel_info["float_kernel"]:
+            context["validation_mode"] = "float"
 
         cmake_context = {
             "name": name,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
@@ -153,8 +153,11 @@ class OpSub(BinaryBasicMathBase):
             float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
             activation_min = float(self.desc.get("act_min", -1.0e30))
             activation_max = float(self.desc.get("act_max", 1.0e30))
-            input1_q = self._sample_uniform(input1_shape, dtype=float_dtype)
-            input2_q = self._sample_uniform(input2_shape, dtype=float_dtype)
+            # Draw both operands from one RNG stream: reseeding per call would
+            # make input1 == input2 and the golden identically zero.
+            input1_f32, input2_f32 = self._sample_dual_uniform_inputs(input1_shape, input2_shape)
+            input1_q = input1_f32.astype(float_dtype)
+            input2_q = input2_f32.astype(float_dtype)
             output_data = np.clip(
                 input1_q.astype(np.float32) - input2_q.astype(np.float32),
                 activation_min,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
@@ -27,6 +27,8 @@ class OpSub(BinaryBasicMathBase):
             dtype = "int8"
         elif activation_dtype == "S16":
             dtype = "int16"
+        elif activation_dtype == "FP32":
+            dtype = "float32"
         elif activation_dtype == "FP16":
             dtype = "float16"
         else:
@@ -72,6 +74,13 @@ class OpSub(BinaryBasicMathBase):
                 'input_c_type': 'int16_t',
                 'output_c_type': 'int16_t',
                 'float_kernel': False,
+            }
+        elif activation_dtype == 'FP32':
+            return {
+                'kernel_fn': 'arm_elementwise_sub_f32',
+                'input_c_type': 'float',
+                'output_c_type': 'float',
+                'float_kernel': True,
             }
         elif activation_dtype == 'FP16':
             return {
@@ -139,17 +148,18 @@ class OpSub(BinaryBasicMathBase):
         activation_dtype = self.tensor_dtype("input", default="S8")
 
         if kernel_info["float_kernel"]:
-            # arm_elementwise_sub_f16 has no broadcast support, so both inputs
-            # must already share the same shape.
+            # The float elementwise sub kernels have no broadcast support, so
+            # both inputs must already share the same shape.
+            float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
             activation_min = float(self.desc.get("act_min", -1.0e30))
             activation_max = float(self.desc.get("act_max", 1.0e30))
-            input1_q = self._sample_uniform(input1_shape, dtype=np.float16)
-            input2_q = self._sample_uniform(input2_shape, dtype=np.float16)
+            input1_q = self._sample_uniform(input1_shape, dtype=float_dtype)
+            input2_q = self._sample_uniform(input2_shape, dtype=float_dtype)
             output_data = np.clip(
                 input1_q.astype(np.float32) - input2_q.astype(np.float32),
                 activation_min,
                 activation_max,
-            ).astype(np.float16)
+            ).astype(float_dtype)
             activation_min_literal = builder.format_float_literal(activation_min)
             activation_max_literal = builder.format_float_literal(activation_max)
             mult1 = shift1 = mult2 = shift2 = output_mult = output_shift = left_shift = 0

--- a/helia_core_tester/generation/ops/StridedSliceFunctions/strided_slice.py
+++ b/helia_core_tester/generation/ops/StridedSliceFunctions/strided_slice.py
@@ -15,11 +15,11 @@ class OpStridedSlice(OperationBase):
     """
 
     def needs_keras_model(self) -> bool:
-        # FP16 uses a LiteRT-only single-op model (Keras/TFLiteConverter has no
-        # reliable FP16 activation path); quantized dtypes keep the existing
-        # Keras-based pipeline.
+        # Float dtypes use a LiteRT-only single-op model (Keras/TFLiteConverter
+        # has no reliable float activation path for single-op slices);
+        # quantized dtypes keep the existing Keras-based pipeline.
         activation_dtype = str(self.desc.get('activation_dtype', 'S8')).upper()
-        return activation_dtype != 'FP16'
+        return activation_dtype not in ('FP16', 'FP32')
 
     def build_keras_model(self) -> tf.keras.Model:
         """Build Keras model for StridedSlice operation."""
@@ -62,7 +62,7 @@ class OpStridedSlice(OperationBase):
         """Convert Keras model to TFLite with quantization."""
         activation_dtype = str(self.desc.get('activation_dtype', 'S8')).upper()
 
-        if activation_dtype == 'FP16':
+        if activation_dtype in ('FP16', 'FP32'):
             from helia_core_tester.generation.utils.litert_builder import build_strided_slice_op
 
             input_shape = tuple(self.desc['input_shape'])
@@ -79,7 +79,7 @@ class OpStridedSlice(OperationBase):
                 end=end,
                 strides=strides,
                 shrink_axis_mask=shrink_axis_mask,
-                dtype="float16",
+                dtype="float16" if activation_dtype == 'FP16' else "float32",
             )
             with open(out_path, "wb") as f:
                 f.write(model_bytes)
@@ -153,6 +153,12 @@ class OpStridedSlice(OperationBase):
                 'kernel_fn': 'arm_strided_slice_s32',
                 'input_c_type': 'int32_t',
                 'output_c_type': 'int32_t'
+            }
+        elif activation_dtype == 'FP32':
+            return {
+                'kernel_fn': 'arm_strided_slice_f32',
+                'input_c_type': 'float',
+                'output_c_type': 'float'
             }
         elif activation_dtype == 'FP16':
             return {
@@ -259,11 +265,12 @@ class OpStridedSlice(OperationBase):
         rng_state = self.rng.__getstate__()
         self.rng = np.random.default_rng(self.seed)
 
-        if kernel_info["input_c_type"] == "float16_t":
+        if kernel_info["input_c_type"] in ("float16_t", "float"):
             # StridedSlice is pure data movement, so the golden output can be
             # computed directly via numpy slicing without invoking a TFLite
-            # interpreter (which has no reliable FP16 activation path).
-            input_q = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(np.float16)
+            # interpreter (which has no reliable float activation path).
+            float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
+            input_q = self.rng.uniform(-1.0, 1.0, size=input_shape).astype(float_dtype)
         elif kernel_info["input_c_type"] == "int32_t":
             input_q = self.rng.integers(-1000, 1001, size=input_shape, dtype=np.int32)
         else:
@@ -298,7 +305,7 @@ class OpStridedSlice(OperationBase):
 
         self.rng.__setstate__(rng_state)
 
-        if kernel_info["input_c_type"] == "float16_t":
+        if kernel_info["input_c_type"] in ("float16_t", "float"):
             end_resolved = list(end) if end is not None else list(input_shape)
             while len(end_resolved) < len(input_shape):
                 end_resolved.append(input_shape[len(end_resolved)])
@@ -312,7 +319,9 @@ class OpStridedSlice(OperationBase):
                     i for i in range(len(input_shape)) if shrink_axis_mask & (1 << i)
                 )
                 output_data = np.squeeze(output_data, axis=squeeze_axes)
-            output_data = np.array(output_data).astype(np.float16)
+            output_data = np.array(output_data).astype(
+                np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
+            )
         else:
             # Run inference using LiteRT interpreter
             interpreter = self.load_litert_interpreter(str(tflite_path))
@@ -350,7 +359,7 @@ class OpStridedSlice(OperationBase):
             'output_dtype': kernel_info["output_c_type"],
             'kernel_fn': kernel_info["kernel_fn"],
         }
-        if kernel_info["input_c_type"] == "float16_t":
+        if kernel_info["input_c_type"] in ("float16_t", "float"):
             context["validation_mode"] = "float"
         
         # Render templates

--- a/helia_core_tester/generation/ops/catalog.py
+++ b/helia_core_tester/generation/ops/catalog.py
@@ -70,7 +70,14 @@ OPERATOR_SPECS: Dict[str, OperatorSpec] = {
         "ActivationFunctions/hard_swish_compat.yaml",
         "ActivationFunctions/hard_swish",
     ),
-    "PReLU": _spec("PReLU", "ActivationFunctions", "prelu", "OpPReLU", "ActivationFunctions/prelu.yaml", "ActivationFunctions/prelu"),
+    "PReLU": _spec(
+        "PReLU",
+        "ActivationFunctions",
+        "prelu",
+        "OpPReLU",
+        descriptor_relpaths=("ActivationFunctions/prelu.yaml", "ActivationFunctions/prelu_float.yaml"),
+        template_relpath="ActivationFunctions/prelu",
+    ),
     "PReLUScalar": _spec(
         "PReLUScalar",
         "ActivationFunctions",
@@ -101,7 +108,14 @@ OPERATOR_SPECS: Dict[str, OperatorSpec] = {
         "ActivationFunctions/hard_swish_precise.yaml",
         "ActivationFunctions/hard_swish",
     ),
-    "Abs": _spec("Abs", "BasicMathFunctions", "abs", "OpAbs", "BasicMathFunctions/abs.yaml", "BasicMathFunctions/abs"),
+    "Abs": _spec(
+        "Abs",
+        "BasicMathFunctions",
+        "abs",
+        "OpAbs",
+        descriptor_relpaths=("BasicMathFunctions/abs.yaml", "BasicMathFunctions/abs_float.yaml"),
+        template_relpath="BasicMathFunctions/abs",
+    ),
     "Add": _spec(
         "Add",
         "BasicMathFunctions",

--- a/helia_core_tester/generation/utils/litert_builder.py
+++ b/helia_core_tester/generation/utils/litert_builder.py
@@ -1709,19 +1709,23 @@ def build_prelu_op(
             )
 
     quant = _default_quant(tensor_type)
-    if quant is None:
-        raise ValueError("Missing default quantization for tensor type.")
-    scale = float(quant[0][0])
-    zero_point = int(quant[1][0])
-
     alpha_float = np.array(alpha_values, dtype=np.float32).reshape(alpha_shape)
-    alpha_q = np.round(alpha_float / scale + zero_point).astype(np.int32)
-    if tensor_type == litert.TensorType.INT8:
-        alpha_q = np.clip(alpha_q, -128, 127).astype(np.int8)
-    elif tensor_type == litert.TensorType.INT16:
-        alpha_q = np.clip(alpha_q, -32768, 32767).astype(np.int16)
+    if tensor_type == litert.TensorType.FLOAT32:
+        alpha_q = alpha_float.astype(np.float32)
+    elif tensor_type == litert.TensorType.FLOAT16:
+        alpha_q = alpha_float.astype(np.float16)
+    elif quant is None:
+        raise ValueError("Missing default quantization for tensor type.")
     else:
-        raise ValueError(f"Unsupported tensor type for alpha: {tensor_type}")
+        scale = float(quant[0][0])
+        zero_point = int(quant[1][0])
+        alpha_q = np.round(alpha_float / scale + zero_point).astype(np.int32)
+        if tensor_type == litert.TensorType.INT8:
+            alpha_q = np.clip(alpha_q, -128, 127).astype(np.int8)
+        elif tensor_type == litert.TensorType.INT16:
+            alpha_q = np.clip(alpha_q, -32768, 32767).astype(np.int16)
+        else:
+            raise ValueError(f"Unsupported tensor type for alpha: {tensor_type}")
 
     builder = LiteRtSingleOpBuilder(op_name="PRELU")
 


### PR DESCRIPTION
## Summary

Extends the float suite to the four kernels gaining FP32/FP16 variants in ns-cmsis-nn [#239](https://github.com/AmbiqAI/ns-cmsis-nn/pull/239), [#240](https://github.com/AmbiqAI/ns-cmsis-nn/pull/240), [#241](https://github.com/AmbiqAI/ns-cmsis-nn/pull/241) — closing the gap where those kernels had zero PR-gated coverage (PR CI runs only helia-core-tester, and these four ops' descriptors were S8/S16-only).

| Op | What was added |
|---|---|
| Sub | FP32 kernel selection (`arm_elementwise_sub_f32`) + 3 FP32 cases; existing float template branch reused |
| StridedSlice | FP32 kernel selection (`arm_strided_slice_f32`) + 5 FP32 cases mirroring every f16 dispatch-path case; LiteRT-only model path extended to FP32 |
| Abs | Full float pipeline: FP32/FP16 descriptors (4 cases), catalog registration, numpy golden, float template branch for the minimal `(input, output, block_size)` signature |
| PReLU | Full float pipeline: FP32/FP16 descriptors (per-channel / full / scalar alpha, 6 cases), float alpha support in `build_prelu_op`, dedicated float generation path (descriptor-derived alpha, numpy broadcast golden), float template branch for the dims-based signature |

## Validation

- Full `--suite float` generation runs clean (linux/arm64 container; ai-edge-litert has no macOS wheels).
- All 26 generated float harnesses for these four ops **cross-compile for Cortex-M55 with -Werror** against a ns-cmsis-nn checkout integrating PRs #239–#241 — argument lists verified against the real kernel signatures, not assumed.
- Tester unit tests: 27/28 pass; the one failure (`test_descriptor_naming_contract`) fails identically on pristine `main` and is unrelated.

## Merge ordering

The new cases call kernels that only exist in ns-cmsis-nn PRs #239–#241, so those must merge first. After this PR lands and is tagged, bump the `Tests/helia-core-tester` submodule pointer in ns-cmsis-nn so the new kernels are PR-gated from then on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)