### PR TITLE
fix: sample distinct operands for Add/Mul/MinMax goldens (#48)

### DIFF
--- a/helia_core_tester/generation/ops/BasicMathFunctions/add.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/add.py
@@ -151,8 +151,11 @@ class OpAdd(BinaryBasicMathBase):
 
         if kernel_info["float_kernel"]:
             float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
-            input1_q = self._sample_uniform(input1_shape, dtype=float_dtype)
-            input2_q = self._sample_uniform(input2_shape, dtype=float_dtype)
+            # Draw both operands from one RNG stream: reseeding per call would
+            # make input1 == input2 and the golden collapse to 2*input1.
+            input1_f32, input2_f32 = self._sample_dual_uniform_inputs(input1_shape, input2_shape)
+            input1_q = input1_f32.astype(float_dtype)
+            input2_q = input2_f32.astype(float_dtype)
             activation_min = float(self.desc.get("act_min", -1.0e30))
             activation_max = float(self.desc.get("act_max", 1.0e30))
             output_data = np.clip(
@@ -190,8 +193,9 @@ class OpAdd(BinaryBasicMathBase):
             output_shift = addsub_qparams["out_shift"]
             left_shift = addsub_qparams["left_shift"]
 
-            input1_data = self._sample_uniform(input1_shape)
-            input2_data = self._sample_uniform(input2_shape)
+            # Draw both operands from one RNG stream: reseeding per call would
+            # make input1 == input2 and weaken/vacuously pass the golden.
+            input1_data, input2_data = self._sample_dual_uniform_inputs(input1_shape, input2_shape)
             qmin, qmax = activation_bounds(activation_dtype)
             np_in_dtype = np.int16 if activation_dtype == "S16" else np.int8
             input1_q = np.round(input1_data / float(input1_scale) + float(input1_zp)).astype(np.int32)

--- a/helia_core_tester/generation/ops/BasicMathFunctions/minmax.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/minmax.py
@@ -153,8 +153,9 @@ class OpMinMax(BinaryBasicMathBase):
         input2_dims = builder.nhwc_to_cmsis_dims(input2_shape)
         output_dims = builder.nhwc_to_cmsis_dims(output_shape)
         
-        input1_data = self._sample_uniform(input1_shape)
-        input2_data = self._sample_uniform(input2_shape)
+        # Draw both operands from one RNG stream: reseeding per call would make
+        # input1 == input2 and the golden collapse to min(x,x)/max(x,x) == x.
+        input1_data, input2_data = self._sample_dual_uniform_inputs(input1_shape, input2_shape)
 
         float_kernel = kernel_info["input_c_type"] in {"float", "float16_t"}
         if float_kernel:

--- a/helia_core_tester/generation/ops/BasicMathFunctions/mul.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/mul.py
@@ -121,8 +121,11 @@ class OpMul(BinaryBasicMathBase):
         activation_dtype = self.tensor_dtype("input")
         if kernel_info["float_kernel"]:
             float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
-            input1_q = self._sample_uniform(input1_shape, dtype=float_dtype)
-            input2_q = self._sample_uniform(input2_shape, dtype=float_dtype)
+            # Draw both operands from one RNG stream: reseeding per call would
+            # make input1 == input2 and the golden collapse to input1**2.
+            input1_f32, input2_f32 = self._sample_dual_uniform_inputs(input1_shape, input2_shape)
+            input1_q = input1_f32.astype(float_dtype)
+            input2_q = input2_f32.astype(float_dtype)
             activation_min = float(self.desc.get("act_min", -1.0e30))
             activation_max = float(self.desc.get("act_max", 1.0e30))
             output_data = np.clip(
@@ -147,8 +150,7 @@ class OpMul(BinaryBasicMathBase):
             effective_scale = (float(input1_scale) * float(input2_scale)) / float(output_scale)
             output_mult, output_shift = calculate_multiplier_shift(effective_scale)
             activation_min, activation_max = activation_bounds(activation_dtype)
-            input1_data = self._sample_uniform(input1_shape)
-            input2_data = self._sample_uniform(input2_shape)
+            input1_data, input2_data = self._sample_dual_uniform_inputs(input1_shape, input2_shape)
             qmin, qmax = activation_bounds(activation_dtype)
             np_in_dtype = np.int16 if activation_dtype == "S16" else np.int8
             input1_q = np.round(input1_data / float(input1_scale) + float(input1_zp)).astype(np.int32)


### PR DESCRIPTION
## Summary

Fixes #48: Add/Mul (and MinMax/Maximum) float and int goldens were using identical operands (`x+x`, `x*x`, `min(x,x)`, `max(x,x)`) because `_sample_uniform()` reseeds a fresh RNG from `self.seed` on every call — two consecutive calls with the same shape produce identical arrays.

This weakens golden coverage: a kernel that returns `2*input1` while silently ignoring `input2`, or one that swaps/mixes up operand order, would still pass.

## Changes

- `add.py`: both the float path (`arm_elementwise_add_f32/f16`) and the int path (`arm_add_s8/s16`) now use `_sample_dual_uniform_inputs()` instead of two separate `_sample_uniform()` calls.
- `mul.py`: same fix applied to both float and int paths.
- `minmax.py`: same fix applied (shared code path for both `Minimum` and `Maximum`, S8/S16/FP16/FP32).

`_sample_dual_uniform_inputs()` draws both operands from a single shared RNG stream, so `input1 != input2` in the generated goldens — the same pattern already used by the comparison ops and by `sub.py`'s int path.

## Audit of other multi-input ops (per issue's ask)

- `squared_difference.py` and `batch_matmul.py` already use a single persistent `self.rng` stream (save/restore state) for both operands — not affected by this bug.
- `sub.py`'s float path has the same bug, but it's already fixed on the currently-open PR #47 branch, so it's left untouched here to avoid stepping on that PR.

## Validation

- `python -m pytest helia_core_tester/tests/` — same 11 pre-existing failures on `main` before and after this change (confirmed via `git stash`); no new failures.
- `python -m helia_core_tester generate --op Add --suite both` runs clean; inspected generated `add_float_default_f32_add.h` and confirmed `input1`/`input2` arrays are now distinct (previously identical).
- Manually verified `_sample_uniform()` called twice with the same shape returns identical arrays, while `_sample_dual_uniform_inputs()` returns distinct arrays.
