### PR TITLE
fix(validation): float outputs always get float comparison (#54)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,13 @@ add_library(cmsis_startup STATIC)
 # Linker script (GNU)
 set(LINK_FILE ${FVP_CORSTONE_300_PATH}/linker.ld)
 
+# ---------- Shared generated-test runtime ----------
+# Runtime/validation logic common to every generated test .c file, compiled
+# once here instead of being re-emitted by Jinja into each generated file.
+add_library(helia_test_runtime STATIC src/test_runtime/helia_test_runtime.c)
+target_include_directories(helia_test_runtime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
+target_compile_definitions(helia_test_runtime PUBLIC USING_FVP_CORSTONE_300)
+
 # ---------- Helpers ----------
 function(_normalize_target_name out_var in_path)
   get_filename_component(_tgt "${in_path}" NAME)
@@ -233,7 +240,7 @@ foreach(TEST_DIR_REL ${GENERATED_TEST_DIRS})
     # Pull in libgcov runtime symbols and emit gcov metadata in the final ELF.
     target_link_options(${TGT_NAME} PRIVATE --coverage)
   endif()
-  target_link_libraries(${TGT_NAME} PRIVATE cmsis-nn retarget cmsis_startup)
+  target_link_libraries(${TGT_NAME} PRIVATE cmsis-nn retarget cmsis_startup helia_test_runtime)
 
   list(APPEND GENERATED_TEST_TARGETS ${TGT_NAME})
 endforeach()

--- a/assets/descriptors/ActivationFunctions/nn_activation_float.yaml
+++ b/assets/descriptors/ActivationFunctions/nn_activation_float.yaml
@@ -101,6 +101,16 @@ input_shape:
 - 16
 activation_type: ARM_NN_FLT_ACT_TANH
 act_param: 0.0
+# Scalar-fallback floor, NOT the MVE floor: the m55-f16-fallback CI leg
+# compiles the kernel at -O0 with ARM_MATH_AUTOVECTORIZE (scalar f16 tanh),
+# where the worst measured diff is 1.03e-2 at |exp|=0.66 -- the MVE path
+# measures ~0 error here, which is how an earlier audit mistook this
+# override for dead weight and removed it (third-round review caught the
+# fallback leg breaking). rtol 0.02 gives ~1.4x margin over that floor.
+comparison:
+  atol: 0.001
+  rtol: 0.02
+
 ---
 operator: NNActivationFloat
 name: nn_activation_float_hardswish_f16
@@ -149,6 +159,16 @@ input_shape:
 - 17
 activation_type: ARM_NN_FLT_ACT_TANH
 act_param: 0.0
+# Scalar-fallback floor, NOT the MVE floor: the m55-f16-fallback CI leg
+# compiles the kernel at -O0 with ARM_MATH_AUTOVECTORIZE (scalar f16 tanh),
+# where the worst measured diff is 1.03e-2 at |exp|=0.66 -- the MVE path
+# measures ~0 error here, which is how an earlier audit mistook this
+# override for dead weight and removed it (third-round review caught the
+# fallback leg breaking). rtol 0.02 gives ~1.4x margin over that floor.
+comparison:
+  atol: 0.001
+  rtol: 0.02
+
 ---
 operator: NNActivationFloat
 name: nn_activation_float_hardswish_tail_f16

--- a/assets/descriptors/ActivationFunctions/nn_activation_float.yaml
+++ b/assets/descriptors/ActivationFunctions/nn_activation_float.yaml
@@ -101,9 +101,6 @@ input_shape:
 - 16
 activation_type: ARM_NN_FLT_ACT_TANH
 act_param: 0.0
-comparison:
-  atol: 0.001
-  rtol: 0.015
 ---
 operator: NNActivationFloat
 name: nn_activation_float_hardswish_f16
@@ -152,9 +149,6 @@ input_shape:
 - 17
 activation_type: ARM_NN_FLT_ACT_TANH
 act_param: 0.0
-comparison:
-  atol: 0.001
-  rtol: 0.015
 ---
 operator: NNActivationFloat
 name: nn_activation_float_hardswish_tail_f16

--- a/assets/descriptors/ConvolutionFunctions/convolve_float.yaml
+++ b/assets/descriptors/ConvolutionFunctions/convolve_float.yaml
@@ -295,6 +295,15 @@ strides:
 - 1
 padding: VALID
 use_bias: true
+# Measured floor (issue #54 first real comparisons): patch-GEMM f16
+# accumulation reassociation reaches 1.06-1.11x the FP16 default on this case
+# (worst diff 1.95e-3 at |exp|=0.84). 2e-3/2e-3 gives ~1.9x margin over the
+# measured floor. The f32 twin keeps defaults and carries the fleet's
+# scaling-mutation sensitivity (caught at 29x there).
+comparison:
+  atol: 0.002
+  rtol: 0.002
+
 ---
 operator: Convolve
 name: convolve_float_1xn_generic_k4_valid_f32

--- a/assets/descriptors/ConvolutionFunctions/convolve_float.yaml
+++ b/assets/descriptors/ConvolutionFunctions/convolve_float.yaml
@@ -297,7 +297,7 @@ padding: VALID
 use_bias: true
 # Measured floor (issue #54 first real comparisons): patch-GEMM f16
 # accumulation reassociation reaches 1.06-1.11x the FP16 default on this case
-# (worst diff 1.95e-3 at |exp|=0.84). 2e-3/2e-3 gives ~1.9x margin over the
+# (worst diff 1.95e-3 at |exp|=1.01). 2e-3/2e-3 gives ~1.7x margin over the
 # measured floor. The f32 twin keeps defaults and carries the fleet's
 # scaling-mutation sensitivity (caught at 29x there).
 comparison:

--- a/assets/descriptors/LSTMFunctions/lstm_unidirectional_float.yaml
+++ b/assets/descriptors/LSTMFunctions/lstm_unidirectional_float.yaml
@@ -74,6 +74,15 @@ input_shape:
 - 1
 - 3
 - 4
+# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
+# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
+# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
+# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
+# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
+# mutation sensitivity re-verified at this tolerance (see PR).
+comparison:
+  atol: 0.01
+  rtol: 0.01
 hint:
   force_cmsis: true
 ---
@@ -96,6 +105,15 @@ input_shape:
 - 3
 - 1
 - 4
+# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
+# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
+# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
+# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
+# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
+# mutation sensitivity re-verified at this tolerance (see PR).
+comparison:
+  atol: 0.01
+  rtol: 0.01
 hint:
   force_cmsis: true
 ---
@@ -118,6 +136,15 @@ input_shape:
 - 1
 - 4
 - 5
+# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
+# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
+# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
+# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
+# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
+# mutation sensitivity re-verified at this tolerance (see PR).
+comparison:
+  atol: 0.01
+  rtol: 0.01
 hint:
   force_cmsis: true
 ---
@@ -178,6 +205,15 @@ units: 8
 time_major: false
 cell_clip: 0.75
 input_shape: [2, 4, 6]
+# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
+# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
+# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
+# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
+# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
+# mutation sensitivity re-verified at this tolerance (see PR).
+comparison:
+  atol: 0.01
+  rtol: 0.01
 hint:
   force_cmsis: true
 ---
@@ -198,5 +234,14 @@ units: 9
 time_major: true
 cell_clip: 0.75
 input_shape: [4, 2, 6]
+# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
+# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
+# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
+# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
+# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
+# mutation sensitivity re-verified at this tolerance (see PR).
+comparison:
+  atol: 0.01
+  rtol: 0.01
 hint:
   force_cmsis: true

--- a/assets/descriptors/LSTMFunctions/lstm_unidirectional_float.yaml
+++ b/assets/descriptors/LSTMFunctions/lstm_unidirectional_float.yaml
@@ -74,15 +74,6 @@ input_shape:
 - 1
 - 3
 - 4
-# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
-# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
-# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
-# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
-# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
-# mutation sensitivity re-verified at this tolerance (see PR).
-comparison:
-  atol: 0.01
-  rtol: 0.01
 hint:
   force_cmsis: true
 ---
@@ -105,15 +96,6 @@ input_shape:
 - 3
 - 1
 - 4
-# Recurrent-f16 family tolerance (matches GRU f16, tester PR #52): the FP16
-# default (atol/rtol 1e-3) sits below the f16 LSTM accumulation floor -- first
-# real float comparisons (issue #54) measured diffs up to 4.2e-3 on
-# clip_tail9_time_major_f16 (~3.4x default). 0.01 gives ~3x margin over the
-# measured floor; the kernel repo's own f16 LSTM unit tests use 8e-2. Gate-swap
-# mutation sensitivity re-verified at this tolerance (see PR).
-comparison:
-  atol: 0.01
-  rtol: 0.01
 hint:
   force_cmsis: true
 ---

--- a/assets/templates/ActivationFunctions/clamp/clamp.c.j2
+++ b/assets/templates/ActivationFunctions/clamp/clamp.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Clamp") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/clamp/clamp.h.j2
+++ b/assets/templates/ActivationFunctions/clamp/clamp.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_CLAMP_H
-#define {{ prefix|upper }}_CLAMP_H
+#ifndef {{ name|upper }}_CLAMP_H
+#define {{ name|upper }}_CLAMP_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/hard_swish/hard_swish.c.j2
+++ b/assets/templates/ActivationFunctions/hard_swish/hard_swish.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -26,9 +26,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("HardSwish") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/hard_swish/hard_swish.h.j2
+++ b/assets/templates/ActivationFunctions/hard_swish/hard_swish.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_HARDSWISH_H
-#define {{ prefix|upper }}_HARDSWISH_H
+#ifndef {{ name|upper }}_HARDSWISH_H
+#define {{ name|upper }}_HARDSWISH_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/hard_swish/hard_swish_compat.c.j2
+++ b/assets/templates/ActivationFunctions/hard_swish/hard_swish_compat.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -25,9 +25,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("HardSwish") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/leaky_relu/leaky_relu.c.j2
+++ b/assets/templates/ActivationFunctions/leaky_relu/leaky_relu.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -25,9 +25,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("LeakyReLU") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/leaky_relu/leaky_relu.h.j2
+++ b/assets/templates/ActivationFunctions/leaky_relu/leaky_relu.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_LEAKYRELU_H
-#define {{ prefix|upper }}_LEAKYRELU_H
+#ifndef {{ name|upper }}_LEAKYRELU_H
+#define {{ name|upper }}_LEAKYRELU_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/logistic/logistic.c.j2
+++ b/assets/templates/ActivationFunctions/logistic/logistic.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -21,9 +21,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Logistic") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/logistic/logistic.h.j2
+++ b/assets/templates/ActivationFunctions/logistic/logistic.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_LOGISTIC_H
-#define {{ prefix|upper }}_LOGISTIC_H
+#ifndef {{ name|upper }}_LOGISTIC_H
+#define {{ name|upper }}_LOGISTIC_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/nn_activation/nn_activation.c.j2
+++ b/assets/templates/ActivationFunctions/nn_activation/nn_activation.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("NN activation") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/nn_activation/nn_activation.h.j2
+++ b/assets/templates/ActivationFunctions/nn_activation/nn_activation.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_NN_ACTIVATION_H
-#define {{ prefix|upper }}_NN_ACTIVATION_H
+#ifndef {{ name|upper }}_NN_ACTIVATION_H
+#define {{ name|upper }}_NN_ACTIVATION_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/nn_activation_float/nn_activation_float.c.j2
+++ b/assets/templates/ActivationFunctions/nn_activation_float/nn_activation_float.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -19,9 +19,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("NNActivationFloat") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/nn_activation_float/nn_activation_float.h.j2
+++ b/assets/templates/ActivationFunctions/nn_activation_float/nn_activation_float.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_NN_ACTIVATION_FLOAT_H
-#define {{ prefix|upper }}_NN_ACTIVATION_FLOAT_H
+#ifndef {{ name|upper }}_NN_ACTIVATION_FLOAT_H
+#define {{ name|upper }}_NN_ACTIVATION_FLOAT_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/prelu/prelu.c.j2
+++ b/assets/templates/ActivationFunctions/prelu/prelu.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -40,9 +40,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_EXPECTED_STATUS(
         "{{ validation_label | default("PReLU") }}",
         status,

--- a/assets/templates/ActivationFunctions/prelu/prelu.h.j2
+++ b/assets/templates/ActivationFunctions/prelu/prelu.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_PRELU_H
-#define {{ prefix|upper }}_PRELU_H
+#ifndef {{ name|upper }}_PRELU_H
+#define {{ name|upper }}_PRELU_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/prelu_scalar/prelu_scalar.c.j2
+++ b/assets/templates/ActivationFunctions/prelu_scalar/prelu_scalar.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ num_pixels | default(1) }} * {{ block_size }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict scalar_input,
     const {{ input_dtype }}* __restrict alpha,
     {{ output_dtype }}* __restrict output
@@ -33,9 +33,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_scalar_input, {{ name }}_alpha, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_scalar_input, {{ name }}_alpha, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("PReLUScalar") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/prelu_scalar/prelu_scalar.h.j2
+++ b/assets/templates/ActivationFunctions/prelu_scalar/prelu_scalar.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_PRELU_SCALAR_H
-#define {{ prefix|upper }}_PRELU_SCALAR_H
+#ifndef {{ name|upper }}_PRELU_SCALAR_H
+#define {{ name|upper }}_PRELU_SCALAR_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/relu/relu.c.j2
+++ b/assets/templates/ActivationFunctions/relu/relu.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -23,9 +23,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ReLU") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/relu/relu.h.j2
+++ b/assets/templates/ActivationFunctions/relu/relu.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_RELU_H
-#define {{ prefix|upper }}_RELU_H
+#ifndef {{ name|upper }}_RELU_H
+#define {{ name|upper }}_RELU_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/relu6/relu6.c.j2
+++ b/assets/templates/ActivationFunctions/relu6/relu6.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -25,9 +25,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ReLU6") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/relu6/relu6.h.j2
+++ b/assets/templates/ActivationFunctions/relu6/relu6.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_RELU6_H
-#define {{ prefix|upper }}_RELU6_H
+#ifndef {{ name|upper }}_RELU6_H
+#define {{ name|upper }}_RELU6_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ActivationFunctions/tanh/tanh.c.j2
+++ b/assets/templates/ActivationFunctions/tanh/tanh.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -21,9 +21,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Tanh") }}", status);
 
     int failures = 0;

--- a/assets/templates/ActivationFunctions/tanh/tanh.h.j2
+++ b/assets/templates/ActivationFunctions/tanh/tanh.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_TANH_H
-#define {{ prefix|upper }}_TANH_H
+#ifndef {{ name|upper }}_TANH_H
+#define {{ name|upper }}_TANH_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/abs/abs.c.j2
+++ b/assets/templates/BasicMathFunctions/abs/abs.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -34,9 +34,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Abs") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/abs/abs.h.j2
+++ b/assets/templates/BasicMathFunctions/abs/abs.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_ABS_H
-#define {{ prefix|upper }}_ABS_H
+#ifndef {{ name|upper }}_ABS_H
+#define {{ name|upper }}_ABS_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/add/add.c.j2
+++ b/assets/templates/BasicMathFunctions/add/add.c.j2
@@ -13,7 +13,7 @@ extern arm_cmsis_nn_status arm_elementwise_add_fp16(const float16_t *input_1_vec
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input1,
     const {{ input_dtype }}* __restrict input2,
     {{ output_dtype }}* __restrict output
@@ -54,9 +54,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Add") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/add/add.h.j2
+++ b/assets/templates/BasicMathFunctions/add/add.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_ADD_H
-#define {{ prefix|upper }}_ADD_H
+#ifndef {{ name|upper }}_ADD_H
+#define {{ name|upper }}_ADD_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/argmax/argmax.c.j2
+++ b/assets/templates/BasicMathFunctions/argmax/argmax.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ArgMax") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/argmax/argmax.h.j2
+++ b/assets/templates/BasicMathFunctions/argmax/argmax.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_ARGMAX_H
-#define {{ prefix|upper }}_ARGMAX_H
+#ifndef {{ name|upper }}_ARGMAX_H
+#define {{ name|upper }}_ARGMAX_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/argmin/argmin.c.j2
+++ b/assets/templates/BasicMathFunctions/argmin/argmin.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ArgMin") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/argmin/argmin.h.j2
+++ b/assets/templates/BasicMathFunctions/argmin/argmin.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_ARGMIN_H
-#define {{ prefix|upper }}_ARGMIN_H
+#ifndef {{ name|upper }}_ARGMIN_H
+#define {{ name|upper }}_ARGMIN_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/mean/mean.c.j2
+++ b/assets/templates/BasicMathFunctions/mean/mean.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -25,9 +25,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Mean") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/mean/mean.h.j2
+++ b/assets/templates/BasicMathFunctions/mean/mean.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_MEAN_H
-#define {{ prefix|upper }}_MEAN_H
+#ifndef {{ name|upper }}_MEAN_H
+#define {{ name|upper }}_MEAN_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/minmax/minmax.c.j2
+++ b/assets/templates/BasicMathFunctions/minmax/minmax.c.j2
@@ -8,7 +8,7 @@ static cmsis_nn_context {{ name }}_ctx = { .buf = NULL, .size = 0 };
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input1,
     const {{ input_dtype }}* __restrict input2,
     {{ output_dtype }}* __restrict output
@@ -27,9 +27,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default(operator) }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/minmax/minmax.h.j2
+++ b/assets/templates/BasicMathFunctions/minmax/minmax.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_MINMAX_H
-#define {{ prefix|upper }}_MINMAX_H
+#ifndef {{ name|upper }}_MINMAX_H
+#define {{ name|upper }}_MINMAX_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/mul/mul.c.j2
+++ b/assets/templates/BasicMathFunctions/mul/mul.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input1,
     const {{ input_dtype }}* __restrict input2,
     {{ output_dtype }}* __restrict output
@@ -41,9 +41,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Mul") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/mul/mul.h.j2
+++ b/assets/templates/BasicMathFunctions/mul/mul.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_MUL_H
-#define {{ prefix|upper }}_MUL_H
+#ifndef {{ name|upper }}_MUL_H
+#define {{ name|upper }}_MUL_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/reduce_max/reduce_max.c.j2
+++ b/assets/templates/BasicMathFunctions/reduce_max/reduce_max.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -21,9 +21,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ReduceMax") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/reduce_max/reduce_max.h.j2
+++ b/assets/templates/BasicMathFunctions/reduce_max/reduce_max.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_REDUCEMAX_H
-#define {{ prefix|upper }}_REDUCEMAX_H
+#ifndef {{ name|upper }}_REDUCEMAX_H
+#define {{ name|upper }}_REDUCEMAX_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/reduce_min/reduce_min.c.j2
+++ b/assets/templates/BasicMathFunctions/reduce_min/reduce_min.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -21,9 +21,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ReduceMin") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/reduce_min/reduce_min.h.j2
+++ b/assets/templates/BasicMathFunctions/reduce_min/reduce_min.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_REDUCEMIN_H
-#define {{ prefix|upper }}_REDUCEMIN_H
+#ifndef {{ name|upper }}_REDUCEMIN_H
+#define {{ name|upper }}_REDUCEMIN_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/reduce_sum/reduce_sum.c.j2
+++ b/assets/templates/BasicMathFunctions/reduce_sum/reduce_sum.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -21,9 +21,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ReduceSum") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/reduce_sum/reduce_sum.h.j2
+++ b/assets/templates/BasicMathFunctions/reduce_sum/reduce_sum.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ name|upper }}_REDUCEMAX_H
-#define {{ name|upper }}_REDUCEMAX_H
+#ifndef {{ name|upper }}_REDUCESUM_H
+#define {{ name|upper }}_REDUCESUM_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/reduce_sum/reduce_sum.h.j2
+++ b/assets/templates/BasicMathFunctions/reduce_sum/reduce_sum.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_REDUCEMAX_H
-#define {{ prefix|upper }}_REDUCEMAX_H
+#ifndef {{ name|upper }}_REDUCEMAX_H
+#define {{ name|upper }}_REDUCEMAX_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/rsqrt/rsqrt.c.j2
+++ b/assets/templates/BasicMathFunctions/rsqrt/rsqrt.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -40,9 +40,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_EXPECTED_STATUS(
         "{{ validation_label | default("Rsqrt") }}",
         status,

--- a/assets/templates/BasicMathFunctions/rsqrt/rsqrt.h.j2
+++ b/assets/templates/BasicMathFunctions/rsqrt/rsqrt.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_RSQRT_H
-#define {{ prefix|upper }}_RSQRT_H
+#ifndef {{ name|upper }}_RSQRT_H
+#define {{ name|upper }}_RSQRT_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/sqrt/sqrt.c.j2
+++ b/assets/templates/BasicMathFunctions/sqrt/sqrt.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Sqrt") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/sqrt/sqrt.h.j2
+++ b/assets/templates/BasicMathFunctions/sqrt/sqrt.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SQRT_H
-#define {{ prefix|upper }}_SQRT_H
+#ifndef {{ name|upper }}_SQRT_H
+#define {{ name|upper }}_SQRT_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"
@@ -29,4 +29,4 @@ static const {{ output_dtype }} {{ name }}_expected_output[] = {
 {{ expected_output_array }}
 };
 
-#endif // {{ prefix|upper }}_SQRT_H
+#endif // {{ name|upper }}_SQRT_H

--- a/assets/templates/BasicMathFunctions/squared_difference/squared_difference.c.j2
+++ b/assets/templates/BasicMathFunctions/squared_difference/squared_difference.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input1,
     const {{ input_dtype }}* __restrict input2,
     {{ output_dtype }}* __restrict output
@@ -54,9 +54,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("SquaredDifference") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/squared_difference/squared_difference.h.j2
+++ b/assets/templates/BasicMathFunctions/squared_difference/squared_difference.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SQUARED_DIFFERENCE_H
-#define {{ prefix|upper }}_SQUARED_DIFFERENCE_H
+#ifndef {{ name|upper }}_SQUARED_DIFFERENCE_H
+#define {{ name|upper }}_SQUARED_DIFFERENCE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BasicMathFunctions/sub/sub.c.j2
+++ b/assets/templates/BasicMathFunctions/sub/sub.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input1,
     const {{ input_dtype }}* __restrict input2,
     {{ output_dtype }}* __restrict output
@@ -65,9 +65,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input1, {{ name }}_input2, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Sub") }}", status);
 
     int failures = 0;

--- a/assets/templates/BasicMathFunctions/sub/sub.h.j2
+++ b/assets/templates/BasicMathFunctions/sub/sub.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SUB_H
-#define {{ prefix|upper }}_SUB_H
+#ifndef {{ name|upper }}_SUB_H
+#define {{ name|upper }}_SUB_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/BroadcastFunctions/broadcast_to/broadcast_to.c.j2
+++ b/assets/templates/BroadcastFunctions/broadcast_to/broadcast_to.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
         {{ input_arg | default(name ~ "_input") }},

--- a/assets/templates/BroadcastFunctions/broadcast_to/broadcast_to.h.j2
+++ b/assets/templates/BroadcastFunctions/broadcast_to/broadcast_to.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_BROADCAST_TO_H
-#define {{ prefix|upper }}_BROADCAST_TO_H
+#ifndef {{ name|upper }}_BROADCAST_TO_H
+#define {{ name|upper }}_BROADCAST_TO_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ComparisonFunctions/comparison/comparison.c.j2
+++ b/assets/templates/ComparisonFunctions/comparison/comparison.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_size }})
 static bool {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input_1,
     const {{ input_dtype }}* __restrict input_2,
     bool* __restrict output
@@ -30,9 +30,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input_1, {{ name }}_input_2, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input_1, {{ name }}_input_2, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Comparison") }}", status);
 
     int failures = 0;

--- a/assets/templates/ComparisonFunctions/comparison/comparison.h.j2
+++ b/assets/templates/ComparisonFunctions/comparison/comparison.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_COMPARISON_H
-#define {{ prefix|upper }}_COMPARISON_H
+#ifndef {{ name|upper }}_COMPARISON_H
+#define {{ name|upper }}_COMPARISON_H
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/assets/templates/ConcatenationFunctions/concatenation/concatenation.c.j2
+++ b/assets/templates/ConcatenationFunctions/concatenation/concatenation.c.j2
@@ -12,7 +12,7 @@ static const {{ input_dtype }}* {{ name }}_input_ptrs[] = {
 {% endfor %}
 };
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* const *input_ptrs,
     {{ output_dtype }}* __restrict output
 ) {
@@ -84,9 +84,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input_ptrs, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input_ptrs, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Concatenation") }}", status);
 
     int failures = 0;

--- a/assets/templates/ConcatenationFunctions/concatenation/concatenation.h.j2
+++ b/assets/templates/ConcatenationFunctions/concatenation/concatenation.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_CONCATENATION_H
-#define {{ prefix|upper }}_CONCATENATION_H
+#ifndef {{ name|upper }}_CONCATENATION_H
+#define {{ name|upper }}_CONCATENATION_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ConcatenationFunctions/split/split.c.j2
+++ b/assets/templates/ConcatenationFunctions/split/split.c.j2
@@ -13,7 +13,7 @@ static {{ output_dtype }}* {{ name }}_output_ptrs[] = {
     {% endfor %}
 };
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input
 ) {
     // Call Split kernel
@@ -31,9 +31,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input);
+    int32_t status = {{ name }}_run({{ name }}_input);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Split") }}", status);
 
     int failures = 0;

--- a/assets/templates/ConcatenationFunctions/split/split.h.j2
+++ b/assets/templates/ConcatenationFunctions/split/split.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SPLIT_H
-#define {{ prefix|upper }}_SPLIT_H
+#ifndef {{ name|upper }}_SPLIT_H
+#define {{ name|upper }}_SPLIT_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ConvolutionFunctions/convolve/convolve.c.j2
+++ b/assets/templates/ConvolutionFunctions/convolve/convolve.c.j2
@@ -37,7 +37,7 @@ static const cmsis_nn_bias_data {{ name }}_bias_data = {
 {% endif %}
 {% endif %}
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -181,9 +181,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     {% endif %}
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Convolution") }}", status);
 
     int failures = 0;

--- a/assets/templates/ConvolutionFunctions/convolve/convolve.h.j2
+++ b/assets/templates/ConvolutionFunctions/convolve/convolve.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_CONV2D_H
-#define {{ prefix|upper }}_CONV2D_H
+#ifndef {{ name|upper }}_CONV2D_H
+#define {{ name|upper }}_CONV2D_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ConvolutionFunctions/depthwise_conv/depthwise_conv.c.j2
+++ b/assets/templates/ConvolutionFunctions/depthwise_conv/depthwise_conv.c.j2
@@ -25,7 +25,7 @@ static const cmsis_nn_dims {{ name }}_bias_dims = {
     .w = 1, .c = {{ output_dims.c }}
 };
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -137,9 +137,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Depthwise convolution") }}", status);
 
     int failures = 0;

--- a/assets/templates/ConvolutionFunctions/depthwise_conv/depthwise_conv.h.j2
+++ b/assets/templates/ConvolutionFunctions/depthwise_conv/depthwise_conv.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_DEPTHWISE_CONV2D_H
-#define {{ prefix|upper }}_DEPTHWISE_CONV2D_H
+#ifndef {{ name|upper }}_DEPTHWISE_CONV2D_H
+#define {{ name|upper }}_DEPTHWISE_CONV2D_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ConvolutionFunctions/transpose_conv/transpose_conv.c.j2
+++ b/assets/templates/ConvolutionFunctions/transpose_conv/transpose_conv.c.j2
@@ -27,7 +27,7 @@ static uint8_t {{ name }}_weight_sum_buffer[{{ name|upper }}_WEIGHT_SUM_BUFFER_S
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -148,9 +148,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Transpose convolution") }}", status);
 
     int failures = 0;

--- a/assets/templates/ConvolutionFunctions/transpose_conv/transpose_conv.h.j2
+++ b/assets/templates/ConvolutionFunctions/transpose_conv/transpose_conv.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_TRANSPOSE_CONV_H
-#define {{ prefix|upper }}_TRANSPOSE_CONV_H
+#ifndef {{ name|upper }}_TRANSPOSE_CONV_H
+#define {{ name|upper }}_TRANSPOSE_CONV_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.c.j2
+++ b/assets/templates/DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ operand_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
         {{ operand_arg | default(name ~ "_operand") }},

--- a/assets/templates/DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.h.j2
+++ b/assets/templates/DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_DYNAMIC_UPDATE_SLICE_H
-#define {{ prefix|upper }}_DYNAMIC_UPDATE_SLICE_H
+#ifndef {{ name|upper }}_DYNAMIC_UPDATE_SLICE_H
+#define {{ name|upper }}_DYNAMIC_UPDATE_SLICE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/FullyConnectedFunctions/batch_matmul/batch_matmul.c.j2
+++ b/assets/templates/FullyConnectedFunctions/batch_matmul/batch_matmul.c.j2
@@ -13,7 +13,7 @@ static uint8_t {{ name }}_buffer[{{ name|upper }}_BUFFER_SIZE_MAX];
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input_lhs,
     const {{ input_dtype }}* __restrict input_rhs,
     {{ output_dtype }}* __restrict output
@@ -76,9 +76,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input_lhs, {{ name }}_input_rhs, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input_lhs, {{ name }}_input_rhs, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Batch matmul") }}", status);
 
     int failures = 0;

--- a/assets/templates/FullyConnectedFunctions/batch_matmul/batch_matmul.h.j2
+++ b/assets/templates/FullyConnectedFunctions/batch_matmul/batch_matmul.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_MATMUL_BATCH_H
-#define {{ prefix|upper }}_MATMUL_BATCH_H
+#ifndef {{ name|upper }}_MATMUL_BATCH_H
+#define {{ name|upper }}_MATMUL_BATCH_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/FullyConnectedFunctions/fully_connected/fully_connected.c.j2
+++ b/assets/templates/FullyConnectedFunctions/fully_connected/fully_connected.c.j2
@@ -14,7 +14,7 @@ static uint8_t {{ name }}_buffer[{{ name|upper }}_BUFFER_SIZE_MAX];
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -134,9 +134,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Fully connected") }}", status);
 
     int failures = 0;

--- a/assets/templates/FullyConnectedFunctions/fully_connected/fully_connected.h.j2
+++ b/assets/templates/FullyConnectedFunctions/fully_connected/fully_connected.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_FULLY_CONNECTED_H
-#define {{ prefix|upper }}_FULLY_CONNECTED_H
+#ifndef {{ name|upper }}_FULLY_CONNECTED_H
+#define {{ name|upper }}_FULLY_CONNECTED_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/GatherFunctions/gather/gather.c.j2
+++ b/assets/templates/GatherFunctions/gather/gather.c.j2
@@ -12,7 +12,7 @@ static cmsis_nn_gather_params {{ name }}_params = {
     .coords_rank = {{ coords_rank }},
 };
 
-int32_t {{ prefix }}_{{ name }}_run(const {{ input_dtype }}* __restrict input,
+int32_t {{ name }}_run(const {{ input_dtype }}* __restrict input,
                                    const int32_t* __restrict indices,
                                    {{ output_dtype }}* __restrict output)
 {
@@ -29,9 +29,9 @@ int32_t {{ prefix }}_{{ name }}_run(const {{ input_dtype }}* __restrict input,
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_indices, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_indices, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Gather") }}", status);
 
     int failures = 0;

--- a/assets/templates/GatherFunctions/gather/gather.h.j2
+++ b/assets/templates/GatherFunctions/gather/gather.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_GATHER_H
-#define {{ prefix|upper }}_GATHER_H
+#ifndef {{ name|upper }}_GATHER_H
+#define {{ name|upper }}_GATHER_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/GatherFunctions/gather_nd/gather_nd.c.j2
+++ b/assets/templates/GatherFunctions/gather_nd/gather_nd.c.j2
@@ -11,7 +11,7 @@ static cmsis_nn_gather_nd_params {{ name }}_params = {
     .batch_dims = {{ batch_dims_test }},
 };
 
-int32_t {{ prefix }}_{{ name }}_run(const {{ input_dtype }}* __restrict params,
+int32_t {{ name }}_run(const {{ input_dtype }}* __restrict params,
                                    const int32_t* __restrict indices,
                                    {{ output_dtype }}* __restrict output)
 {
@@ -28,9 +28,9 @@ int32_t {{ prefix }}_{{ name }}_run(const {{ input_dtype }}* __restrict params,
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_params_data, {{ name }}_indices, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_params_data, {{ name }}_indices, {{ name }}_output);
     HELIA_VALIDATE_EXPECTED_STATUS(
         "{{ validation_label | default("GatherND") }}",
         status,

--- a/assets/templates/GatherFunctions/gather_nd/gather_nd.h.j2
+++ b/assets/templates/GatherFunctions/gather_nd/gather_nd.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_GATHER_ND_H
-#define {{ prefix|upper }}_GATHER_ND_H
+#ifndef {{ name|upper }}_GATHER_ND_H
+#define {{ name|upper }}_GATHER_ND_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional.c.j2
+++ b/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional.c.j2
@@ -40,7 +40,7 @@ static int32_t run_gru(void)
     return {{ kernel_fn }}({{ name }}_input_tensor, {{ name }}_output, &params, &buffers);
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     int32_t status = run_gru();
     HELIA_VALIDATE_STATUS("{{ validation_label | default("GRU") }}", status);

--- a/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional.h.j2
+++ b/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_GRU_UNIDIRECTIONAL_H
-#define {{ prefix|upper }}_GRU_UNIDIRECTIONAL_H
+#ifndef {{ name|upper }}_GRU_UNIDIRECTIONAL_H
+#define {{ name|upper }}_GRU_UNIDIRECTIONAL_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional_fault.c.j2
+++ b/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional_fault.c.j2
@@ -53,7 +53,7 @@ static int32_t run_gru(void)
     return {{ kernel_fn }}(input_arg, output_arg, params_arg, &buffers);
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     int32_t status = run_gru();
     HELIA_VALIDATE_EXPECTED_STATUS(

--- a/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional_stream.c.j2
+++ b/assets/templates/LSTMFunctions/gru_unidirectional/gru_unidirectional_stream.c.j2
@@ -51,7 +51,7 @@ static int32_t run_gru_chunk(int32_t chunk_time_steps, int32_t input_offset, int
         &buffers);
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     /* Fresh streaming state for this sequence. */
     for (int32_t h = 0; h < {{ hidden_state_size }}; h++)

--- a/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional.c.j2
+++ b/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional.c.j2
@@ -240,7 +240,7 @@ static int32_t run_lstm(void)
     return result;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     int32_t status = run_lstm();
     HELIA_VALIDATE_STATUS("{{ validation_label | default("LSTM") }}", status);

--- a/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional.h.j2
+++ b/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_LSTM_UNIDIRECTIONAL_H
-#define {{ prefix|upper }}_LSTM_UNIDIRECTIONAL_H
+#ifndef {{ name|upper }}_LSTM_UNIDIRECTIONAL_H
+#define {{ name|upper }}_LSTM_UNIDIRECTIONAL_H
 
 #include <stdint.h>
 

--- a/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional_f32.c.j2
+++ b/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional_f32.c.j2
@@ -49,7 +49,7 @@ static int32_t run_lstm(void)
     return {{ kernel_fn }}({{ name }}_input_tensor, {{ name }}_output, &params, &buffers);
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     int32_t status = run_lstm();
     HELIA_VALIDATE_STATUS("{{ validation_label | default("LSTM") }}", status);

--- a/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional_f32.h.j2
+++ b/assets/templates/LSTMFunctions/lstm_unidirectional/lstm_unidirectional_f32.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_LSTM_UNIDIRECTIONAL_H
-#define {{ prefix|upper }}_LSTM_UNIDIRECTIONAL_H
+#ifndef {{ name|upper }}_LSTM_UNIDIRECTIONAL_H
+#define {{ name|upper }}_LSTM_UNIDIRECTIONAL_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/NNSupportFunctions/batch_norm/batch_norm.c.j2
+++ b/assets/templates/NNSupportFunctions/batch_norm/batch_norm.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ input_dims.n }} * {{ input_dims.h }} * {{ input_dims.w }} * {{ input_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("BatchNorm") }}", status);
 
     int failures = 0;

--- a/assets/templates/NNSupportFunctions/batch_norm/batch_norm.h.j2
+++ b/assets/templates/NNSupportFunctions/batch_norm/batch_norm.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_BATCH_NORM_H
-#define {{ prefix|upper }}_BATCH_NORM_H
+#ifndef {{ name|upper }}_BATCH_NORM_H
+#define {{ name|upper }}_BATCH_NORM_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/NNSupportFunctions/requantize/requantize.c.j2
+++ b/assets/templates/NNSupportFunctions/requantize/requantize.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ input_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -22,9 +22,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Requantize") }}", status);
 
     int failures = 0;

--- a/assets/templates/NNSupportFunctions/requantize/requantize.h.j2
+++ b/assets/templates/NNSupportFunctions/requantize/requantize.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_REQUANTIZE_H
-#define {{ prefix|upper }}_REQUANTIZE_H
+#ifndef {{ name|upper }}_REQUANTIZE_H
+#define {{ name|upper }}_REQUANTIZE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/PadFunctions/mirror_pad/mirror_pad.c.j2
+++ b/assets/templates/PadFunctions/mirror_pad/mirror_pad.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
         {{ name }}_input,

--- a/assets/templates/PadFunctions/mirror_pad/mirror_pad.h.j2
+++ b/assets/templates/PadFunctions/mirror_pad/mirror_pad.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_MIRROR_PAD_H
-#define {{ prefix|upper }}_MIRROR_PAD_H
+#ifndef {{ name|upper }}_MIRROR_PAD_H
+#define {{ name|upper }}_MIRROR_PAD_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/PadFunctions/pad/pad.c.j2
+++ b/assets/templates/PadFunctions/pad/pad.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -22,9 +22,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Pad") }}", status);
 
     int failures = 0;

--- a/assets/templates/PadFunctions/pad/pad.h.j2
+++ b/assets/templates/PadFunctions/pad/pad.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_PAD_H
-#define {{ prefix|upper }}_PAD_H
+#ifndef {{ name|upper }}_PAD_H
+#define {{ name|upper }}_PAD_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/PoolingFunctions/avg_pool/avg_pool.c.j2
+++ b/assets/templates/PoolingFunctions/avg_pool/avg_pool.c.j2
@@ -28,7 +28,7 @@ static uint8_t* {{ name }}_buffer = NULL;
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -67,9 +67,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Pooling") }}", status);
 
     int failures = 0;

--- a/assets/templates/PoolingFunctions/avg_pool/avg_pool.h.j2
+++ b/assets/templates/PoolingFunctions/avg_pool/avg_pool.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_POOLING_H
-#define {{ prefix|upper }}_POOLING_H
+#ifndef {{ name|upper }}_POOLING_H
+#define {{ name|upper }}_POOLING_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/PoolingFunctions/max_pool/max_pool.c.j2
+++ b/assets/templates/PoolingFunctions/max_pool/max_pool.c.j2
@@ -28,7 +28,7 @@ static uint8_t* {{ name }}_buffer = NULL;
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -67,9 +67,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Pooling") }}", status);
 
     int failures = 0;

--- a/assets/templates/PoolingFunctions/max_pool/max_pool.h.j2
+++ b/assets/templates/PoolingFunctions/max_pool/max_pool.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_POOLING_H
-#define {{ prefix|upper }}_POOLING_H
+#ifndef {{ name|upper }}_POOLING_H
+#define {{ name|upper }}_POOLING_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/QuantizationFunctions/dequantize/dequantize.c.j2
+++ b/assets/templates/QuantizationFunctions/dequantize/dequantize.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ input_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -41,9 +41,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return ARM_CMSIS_NN_SUCCESS;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Dequantize") }}", status);
 
     int failures = 0;

--- a/assets/templates/QuantizationFunctions/dequantize/dequantize.h.j2
+++ b/assets/templates/QuantizationFunctions/dequantize/dequantize.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_DEQUANTIZE_H
-#define {{ prefix|upper }}_DEQUANTIZE_H
+#ifndef {{ name|upper }}_DEQUANTIZE_H
+#define {{ name|upper }}_DEQUANTIZE_H
 
 #include <stdint.h>
 #include <float.h>

--- a/assets/templates/QuantizationFunctions/quantize/quantize.c.j2
+++ b/assets/templates/QuantizationFunctions/quantize/quantize.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ input_size }}
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -65,9 +65,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return ARM_CMSIS_NN_SUCCESS;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Quantize") }}", status);
 
     int failures = 0;

--- a/assets/templates/QuantizationFunctions/quantize/quantize.h.j2
+++ b/assets/templates/QuantizationFunctions/quantize/quantize.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_QUANTIZE_H
-#define {{ prefix|upper }}_QUANTIZE_H
+#ifndef {{ name|upper }}_QUANTIZE_H
+#define {{ name|upper }}_QUANTIZE_H
 
 #include <stdint.h>
 #include <float.h>

--- a/assets/templates/ReshapeFunctions/batch_to_space_nd/batch_to_space_nd.c.j2
+++ b/assets/templates/ReshapeFunctions/batch_to_space_nd/batch_to_space_nd.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_size }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -20,9 +20,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("BatchToSpaceND") }}", status);
 
     int failures = 0;

--- a/assets/templates/ReshapeFunctions/batch_to_space_nd/batch_to_space_nd.h.j2
+++ b/assets/templates/ReshapeFunctions/batch_to_space_nd/batch_to_space_nd.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_BATCH_TO_SPACE_ND_H
-#define {{ prefix|upper }}_BATCH_TO_SPACE_ND_H
+#ifndef {{ name|upper }}_BATCH_TO_SPACE_ND_H
+#define {{ name|upper }}_BATCH_TO_SPACE_ND_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ReshapeFunctions/depth_to_space/depth_to_space.c.j2
+++ b/assets/templates/ReshapeFunctions/depth_to_space/depth_to_space.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_size }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -19,9 +19,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("DepthToSpace") }}", status);
 
     int failures = 0;

--- a/assets/templates/ReshapeFunctions/depth_to_space/depth_to_space.h.j2
+++ b/assets/templates/ReshapeFunctions/depth_to_space/depth_to_space.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_DEPTH_TO_SPACE_H
-#define {{ prefix|upper }}_DEPTH_TO_SPACE_H
+#ifndef {{ name|upper }}_DEPTH_TO_SPACE_H
+#define {{ name|upper }}_DEPTH_TO_SPACE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ReshapeFunctions/reshape/reshape.c.j2
+++ b/assets/templates/ReshapeFunctions/reshape/reshape.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -15,9 +15,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return ARM_CMSIS_NN_SUCCESS;  // arm_reshape_s8 returns void
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Reshape") }}", status);
 
     int failures = 0;

--- a/assets/templates/ReshapeFunctions/reshape/reshape.h.j2
+++ b/assets/templates/ReshapeFunctions/reshape/reshape.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_RESHAPE_H
-#define {{ prefix|upper }}_RESHAPE_H
+#ifndef {{ name|upper }}_RESHAPE_H
+#define {{ name|upper }}_RESHAPE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ReshapeFunctions/resize_nearest_neighbor/resize_nearest_neighbor.c.j2
+++ b/assets/templates/ReshapeFunctions/resize_nearest_neighbor/resize_nearest_neighbor.c.j2
@@ -16,7 +16,7 @@ static cmsis_nn_resize_params {{ name }}_params = {
     .half_pixel_centers = {{ half_pixel_centers }},
 };
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -33,9 +33,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("ResizeNearestNeighbor") }}", status);
 
     int failures = 0;

--- a/assets/templates/ReshapeFunctions/resize_nearest_neighbor/resize_nearest_neighbor.h.j2
+++ b/assets/templates/ReshapeFunctions/resize_nearest_neighbor/resize_nearest_neighbor.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_RESIZE_NEAREST_NEIGHBOR_H
-#define {{ prefix|upper }}_RESIZE_NEAREST_NEIGHBOR_H
+#ifndef {{ name|upper }}_RESIZE_NEAREST_NEIGHBOR_H
+#define {{ name|upper }}_RESIZE_NEAREST_NEIGHBOR_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ReshapeFunctions/space_to_batch_nd/space_to_batch_nd.c.j2
+++ b/assets/templates/ReshapeFunctions/space_to_batch_nd/space_to_batch_nd.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_size }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -21,9 +21,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("SpaceToBatchND") }}", status);
 
     int failures = 0;

--- a/assets/templates/ReshapeFunctions/space_to_batch_nd/space_to_batch_nd.h.j2
+++ b/assets/templates/ReshapeFunctions/space_to_batch_nd/space_to_batch_nd.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SPACE_TO_BATCH_ND_H
-#define {{ prefix|upper }}_SPACE_TO_BATCH_ND_H
+#ifndef {{ name|upper }}_SPACE_TO_BATCH_ND_H
+#define {{ name|upper }}_SPACE_TO_BATCH_ND_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ReshapeFunctions/space_to_depth/space_to_depth.c.j2
+++ b/assets/templates/ReshapeFunctions/space_to_depth/space_to_depth.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_size }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -19,9 +19,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("SpaceToDepth") }}", status);
 
     int failures = 0;

--- a/assets/templates/ReshapeFunctions/space_to_depth/space_to_depth.h.j2
+++ b/assets/templates/ReshapeFunctions/space_to_depth/space_to_depth.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SPACE_TO_DEPTH_H
-#define {{ prefix|upper }}_SPACE_TO_DEPTH_H
+#ifndef {{ name|upper }}_SPACE_TO_DEPTH_H
+#define {{ name|upper }}_SPACE_TO_DEPTH_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ReverseSequenceFunctions/reverse_sequence/reverse_sequence.c.j2
+++ b/assets/templates/ReverseSequenceFunctions/reverse_sequence/reverse_sequence.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
         {{ name }}_input,

--- a/assets/templates/ReverseSequenceFunctions/reverse_sequence/reverse_sequence.h.j2
+++ b/assets/templates/ReverseSequenceFunctions/reverse_sequence/reverse_sequence.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_REVERSE_SEQUENCE_H
-#define {{ prefix|upper }}_REVERSE_SEQUENCE_H
+#ifndef {{ name|upper }}_REVERSE_SEQUENCE_H
+#define {{ name|upper }}_REVERSE_SEQUENCE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/SVDFunctions/svdf/svdf.c.j2
+++ b/assets/templates/SVDFunctions/svdf/svdf.c.j2
@@ -3,7 +3,7 @@
 #include <string.h>
 {% include "common/standalone/runtime_common.j2" %}
 
-#define SVDF_OUTPUT_SIZE ({{ prefix|upper }}_INPUT_BATCHES * {{ prefix|upper }}_UNIT_COUNT)
+#define SVDF_OUTPUT_SIZE ({{ name|upper }}_INPUT_BATCHES * {{ name|upper }}_UNIT_COUNT)
 static {{ output_dtype }} {{ name }}_output[SVDF_OUTPUT_SIZE];
 
 static int32_t run_svdf(void)
@@ -17,8 +17,8 @@ static int32_t run_svdf(void)
     cmsis_nn_context ctx;
 {% endif %}
 
-    const int32_t scratch_size = {{ prefix|upper }}_INPUT_BATCHES * {{ prefix|upper }}_FEATURE_BATCHES * sizeof(int32_t);
-    const int32_t scratch_size_out = {{ prefix|upper }}_INPUT_BATCHES * {{ prefix|upper }}_UNIT_COUNT * sizeof(int32_t);
+    const int32_t scratch_size = {{ name|upper }}_INPUT_BATCHES * {{ name|upper }}_FEATURE_BATCHES * sizeof(int32_t);
+    const int32_t scratch_size_out = {{ name|upper }}_INPUT_BATCHES * {{ name|upper }}_UNIT_COUNT * sizeof(int32_t);
 
     input_ctx.buf = malloc(scratch_size);
     input_ctx.size = scratch_size;
@@ -32,30 +32,30 @@ static int32_t run_svdf(void)
 #if defined(ARM_MATH_MVEI)
     if (ctx.buf != NULL) {
         arm_vector_sum_s8((int32_t *)ctx.buf,
-                          {{ prefix|upper }}_INPUT_HEIGHT,
-                          {{ prefix|upper }}_FEATURE_BATCHES,
+                          {{ name|upper }}_INPUT_HEIGHT,
+                          {{ name|upper }}_FEATURE_BATCHES,
                           {{ name }}_weights_feature,
-                          -{{ prefix|upper }}_INPUT_OFFSET,
+                          -{{ name|upper }}_INPUT_OFFSET,
                           0,
                           NULL);
     }
 #endif
 {% endif %}
 
-    svdf_params.input_activation.min = {{ prefix|upper }}_INPUT_ACTIVATION_MIN;
-    svdf_params.input_activation.max = {{ prefix|upper }}_INPUT_ACTIVATION_MAX;
-    svdf_params.output_activation.min = {{ prefix|upper }}_OUTPUT_ACTIVATION_MIN;
-    svdf_params.output_activation.max = {{ prefix|upper }}_OUTPUT_ACTIVATION_MAX;
-    svdf_params.input_offset = {{ prefix|upper }}_INPUT_OFFSET;
-    svdf_params.output_offset = {{ prefix|upper }}_OUTPUT_OFFSET;
-    svdf_params.rank = {{ prefix|upper }}_RANK;
+    svdf_params.input_activation.min = {{ name|upper }}_INPUT_ACTIVATION_MIN;
+    svdf_params.input_activation.max = {{ name|upper }}_INPUT_ACTIVATION_MAX;
+    svdf_params.output_activation.min = {{ name|upper }}_OUTPUT_ACTIVATION_MIN;
+    svdf_params.output_activation.max = {{ name|upper }}_OUTPUT_ACTIVATION_MAX;
+    svdf_params.input_offset = {{ name|upper }}_INPUT_OFFSET;
+    svdf_params.output_offset = {{ name|upper }}_OUTPUT_OFFSET;
+    svdf_params.rank = {{ name|upper }}_RANK;
 
-    input_quant_params.multiplier = {{ prefix|upper }}_INPUT_MULTIPLIER;
-    input_quant_params.shift = {{ prefix|upper }}_INPUT_SHIFT;
-    output_quant_params.multiplier = {{ prefix|upper }}_OUTPUT_MULTIPLIER;
-    output_quant_params.shift = {{ prefix|upper }}_OUTPUT_SHIFT;
+    input_quant_params.multiplier = {{ name|upper }}_INPUT_MULTIPLIER;
+    input_quant_params.shift = {{ name|upper }}_INPUT_SHIFT;
+    output_quant_params.multiplier = {{ name|upper }}_OUTPUT_MULTIPLIER;
+    output_quant_params.shift = {{ name|upper }}_OUTPUT_SHIFT;
 
-    {{ state_dtype }} state_data[{{ prefix|upper }}_INPUT_BATCHES * {{ prefix|upper }}_FEATURE_BATCHES * {{ prefix|upper }}_TIME_BATCHES];
+    {{ state_dtype }} state_data[{{ name|upper }}_INPUT_BATCHES * {{ name|upper }}_FEATURE_BATCHES * {{ name|upper }}_TIME_BATCHES];
     memcpy(state_data, {{ name }}_state_init, sizeof({{ name }}_state_init));
 
     memset({{ name }}_output, 0, sizeof({{ name }}_output));
@@ -122,7 +122,7 @@ static int32_t run_svdf(void)
     return result;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
 {% if has_ctx %}
     int32_t buf_dsp = arm_svdf_s8_get_buffer_size_dsp(&{{ name }}_weights_feature_dims);

--- a/assets/templates/SVDFunctions/svdf/svdf.h.j2
+++ b/assets/templates/SVDFunctions/svdf/svdf.h.j2
@@ -1,28 +1,28 @@
-#ifndef {{ prefix|upper }}_SVDF_H
-#define {{ prefix|upper }}_SVDF_H
+#ifndef {{ name|upper }}_SVDF_H
+#define {{ name|upper }}_SVDF_H
 
 #include <stdint.h>
 #include "arm_nn_types.h"
 
-#define {{ prefix|upper }}_INPUT_BATCHES {{ input_batches }}
-#define {{ prefix|upper }}_INPUT_HEIGHT {{ input_height }}
-#define {{ prefix|upper }}_FEATURE_BATCHES {{ feature_batches }}
-#define {{ prefix|upper }}_TIME_BATCHES {{ time_batches }}
-#define {{ prefix|upper }}_RANK {{ rank }}
-#define {{ prefix|upper }}_UNIT_COUNT {{ unit_count }}
+#define {{ name|upper }}_INPUT_BATCHES {{ input_batches }}
+#define {{ name|upper }}_INPUT_HEIGHT {{ input_height }}
+#define {{ name|upper }}_FEATURE_BATCHES {{ feature_batches }}
+#define {{ name|upper }}_TIME_BATCHES {{ time_batches }}
+#define {{ name|upper }}_RANK {{ rank }}
+#define {{ name|upper }}_UNIT_COUNT {{ unit_count }}
 
-#define {{ prefix|upper }}_INPUT_OFFSET {{ input_offset }}
-#define {{ prefix|upper }}_OUTPUT_OFFSET {{ output_offset }}
+#define {{ name|upper }}_INPUT_OFFSET {{ input_offset }}
+#define {{ name|upper }}_OUTPUT_OFFSET {{ output_offset }}
 
-#define {{ prefix|upper }}_INPUT_MULTIPLIER {{ input_multiplier }}
-#define {{ prefix|upper }}_INPUT_SHIFT {{ input_shift }}
-#define {{ prefix|upper }}_OUTPUT_MULTIPLIER {{ output_multiplier }}
-#define {{ prefix|upper }}_OUTPUT_SHIFT {{ output_shift }}
+#define {{ name|upper }}_INPUT_MULTIPLIER {{ input_multiplier }}
+#define {{ name|upper }}_INPUT_SHIFT {{ input_shift }}
+#define {{ name|upper }}_OUTPUT_MULTIPLIER {{ output_multiplier }}
+#define {{ name|upper }}_OUTPUT_SHIFT {{ output_shift }}
 
-#define {{ prefix|upper }}_INPUT_ACTIVATION_MIN {{ input_activation_min }}
-#define {{ prefix|upper }}_INPUT_ACTIVATION_MAX {{ input_activation_max }}
-#define {{ prefix|upper }}_OUTPUT_ACTIVATION_MIN {{ output_activation_min }}
-#define {{ prefix|upper }}_OUTPUT_ACTIVATION_MAX {{ output_activation_max }}
+#define {{ name|upper }}_INPUT_ACTIVATION_MIN {{ input_activation_min }}
+#define {{ name|upper }}_INPUT_ACTIVATION_MAX {{ input_activation_max }}
+#define {{ name|upper }}_OUTPUT_ACTIVATION_MIN {{ output_activation_min }}
+#define {{ name|upper }}_OUTPUT_ACTIVATION_MAX {{ output_activation_max }}
 
 static const cmsis_nn_dims {{ name }}_input_dims = {
     .n = {{ input_batches }}, .h = {{ input_height }}, .w = 1, .c = 1

--- a/assets/templates/SVDFunctions/svdf/svdf_f32.c.j2
+++ b/assets/templates/SVDFunctions/svdf/svdf_f32.c.j2
@@ -48,7 +48,7 @@ static int32_t run_svdf(void)
     return ARM_CMSIS_NN_SUCCESS;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     int32_t status = run_svdf();
     HELIA_VALIDATE_STATUS("{{ validation_label | default("SVDF") }}", status);

--- a/assets/templates/SVDFunctions/svdf/svdf_f32.h.j2
+++ b/assets/templates/SVDFunctions/svdf/svdf_f32.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SVDF_H
-#define {{ prefix|upper }}_SVDF_H
+#ifndef {{ name|upper }}_SVDF_H
+#define {{ name|upper }}_SVDF_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/ScatterFunctions/scatter_nd/scatter_nd.c.j2
+++ b/assets/templates/ScatterFunctions/scatter_nd/scatter_nd.c.j2
@@ -6,7 +6,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     memset({{ name }}_output, 0, sizeof({{ name }}_output));
     arm_cmsis_nn_status status = {{ kernel_fn }}(

--- a/assets/templates/ScatterFunctions/scatter_nd/scatter_nd.h.j2
+++ b/assets/templates/ScatterFunctions/scatter_nd/scatter_nd.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SCATTER_ND_H
-#define {{ prefix|upper }}_SCATTER_ND_H
+#ifndef {{ name|upper }}_SCATTER_ND_H
+#define {{ name|upper }}_SCATTER_ND_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/SelectFunctions/select_v2/select_v2.c.j2
+++ b/assets/templates/SelectFunctions/select_v2/select_v2.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
         {{ name }}_condition,

--- a/assets/templates/SelectFunctions/select_v2/select_v2.h.j2
+++ b/assets/templates/SelectFunctions/select_v2/select_v2.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SELECT_V2_H
-#define {{ prefix|upper }}_SELECT_V2_H
+#ifndef {{ name|upper }}_SELECT_V2_H
+#define {{ name|upper }}_SELECT_V2_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/SelectFunctions/where/where.c.j2
+++ b/assets/templates/SelectFunctions/where/where.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_MAX_OUTPUT_SIZE {{ max_output_size }}
 static {{ output_c_type }} {{ name }}_output[{{ name|upper }}_MAX_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     int32_t num_true = 0;
     arm_cmsis_nn_status status = {{ kernel_fn }}(

--- a/assets/templates/SelectFunctions/where/where.h.j2
+++ b/assets/templates/SelectFunctions/where/where.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_WHERE_H
-#define {{ prefix|upper }}_WHERE_H
+#ifndef {{ name|upper }}_WHERE_H
+#define {{ name|upper }}_WHERE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/SoftmaxFunctions/softmax/softmax.c.j2
+++ b/assets/templates/SoftmaxFunctions/softmax/softmax.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -44,9 +44,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Softmax") }}", status);
 
     int failures = 0;

--- a/assets/templates/SoftmaxFunctions/softmax/softmax.h.j2
+++ b/assets/templates/SoftmaxFunctions/softmax/softmax.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SOFTMAX_H
-#define {{ prefix|upper }}_SOFTMAX_H
+#ifndef {{ name|upper }}_SOFTMAX_H
+#define {{ name|upper }}_SOFTMAX_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/StridedSliceFunctions/strided_slice/strided_slice.c.j2
+++ b/assets/templates/StridedSliceFunctions/strided_slice/strided_slice.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -22,9 +22,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("StridedSlice") }}", status);
 
     int failures = 0;

--- a/assets/templates/StridedSliceFunctions/strided_slice/strided_slice.h.j2
+++ b/assets/templates/StridedSliceFunctions/strided_slice/strided_slice.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_STRIDEDSLICE_H
-#define {{ prefix|upper }}_STRIDEDSLICE_H
+#ifndef {{ name|upper }}_STRIDEDSLICE_H
+#define {{ name|upper }}_STRIDEDSLICE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/TesterExtensions/squeeze/squeeze.c.j2
+++ b/assets/templates/TesterExtensions/squeeze/squeeze.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -16,9 +16,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return ARM_CMSIS_NN_SUCCESS;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_STATUS("{{ validation_label | default("Squeeze") }}", status);
 
     int failures = 0;

--- a/assets/templates/TesterExtensions/squeeze/squeeze.h.j2
+++ b/assets/templates/TesterExtensions/squeeze/squeeze.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_SQUEEZE_H
-#define {{ prefix|upper }}_SQUEEZE_H
+#ifndef {{ name|upper }}_SQUEEZE_H
+#define {{ name|upper }}_SQUEEZE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/TileFunctions/tile/tile.c.j2
+++ b/assets/templates/TileFunctions/tile/tile.c.j2
@@ -5,7 +5,7 @@
 #define {{ name|upper }}_OUTPUT_SIZE {{ output_size }}
 static {{ c_type }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
     arm_cmsis_nn_status status = {{ kernel_fn }}(
         {{ name }}_input,

--- a/assets/templates/TileFunctions/tile/tile.h.j2
+++ b/assets/templates/TileFunctions/tile/tile.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_TILE_H
-#define {{ prefix|upper }}_TILE_H
+#ifndef {{ name|upper }}_TILE_H
+#define {{ name|upper }}_TILE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/TransposeFunctions/transpose/transpose.c.j2
+++ b/assets/templates/TransposeFunctions/transpose/transpose.c.j2
@@ -9,7 +9,7 @@ static cmsis_nn_context {{ name }}_ctx = { .buf = NULL, .size = 0 };
 #define {{ name|upper }}_OUTPUT_SIZE ({{ output_dims.n }} * {{ output_dims.h }} * {{ output_dims.w }} * {{ output_dims.c }})
 static {{ output_dtype }} {{ name }}_output[{{ name|upper }}_OUTPUT_SIZE];
 
-int32_t {{ prefix }}_{{ name }}_run(
+int32_t {{ name }}_run(
     const {{ input_dtype }}* __restrict input,
     {{ output_dtype }}* __restrict output
 ) {
@@ -36,9 +36,9 @@ int32_t {{ prefix }}_{{ name }}_run(
     return kernel_status;
 }
 
-int32_t {{ prefix }}_{{ name }}_test_case_run(void)
+int32_t {{ name }}_test_case_run(void)
 {
-    int32_t status = {{ prefix }}_{{ name }}_run({{ name }}_input, {{ name }}_output);
+    int32_t status = {{ name }}_run({{ name }}_input, {{ name }}_output);
     HELIA_VALIDATE_EXPECTED_STATUS(
         "{{ validation_label | default("Transpose") }}",
         status,

--- a/assets/templates/TransposeFunctions/transpose/transpose.h.j2
+++ b/assets/templates/TransposeFunctions/transpose/transpose.h.j2
@@ -1,5 +1,5 @@
-#ifndef {{ prefix|upper }}_TRANSPOSE_H
-#define {{ prefix|upper }}_TRANSPOSE_H
+#ifndef {{ name|upper }}_TRANSPOSE_H
+#define {{ name|upper }}_TRANSPOSE_H
 
 #include <stdint.h>
 #include "arm_nnfunctions.h"

--- a/assets/templates/common/standalone/main.j2
+++ b/assets/templates/common/standalone/main.j2
@@ -1,6 +1,6 @@
 int main(void)
 {
     helia_test_platform_init();
-    int32_t failures = {{ prefix }}_{{ name }}_test_case_run();
+    int32_t failures = {{ name }}_test_case_run();
     helia_test_finish(failures);
 }

--- a/assets/templates/common/standalone/runtime_common.j2
+++ b/assets/templates/common/standalone/runtime_common.j2
@@ -1,39 +1,7 @@
 #include <stdio.h>
 #include <stdint.h>
+{% if needs_stdlib | default(false) %}
 #include <stdlib.h>
+{% endif %}
+#include "test_runtime/helia_test_runtime.h"
 
-{% include "common/validate.j2" %}
-
-#ifdef USING_FVP_CORSTONE_300
-extern void uart_init(void);
-#endif
-
-static inline void helia_test_platform_init(void)
-{
-#ifdef USING_FVP_CORSTONE_300
-    uart_init();
-#endif
-    setvbuf(stdout, NULL, _IONBF, 0);
-}
-
-static inline void signal_eot(void)
-{
-    // 0x04 (EOT) triggers FVP shutdown when:
-    //   -C mps3_board.uart0.shutdown_on_eot=1
-    putchar(4);
-    fflush(stdout);
-}
-
-static inline void helia_test_finish(int32_t failures)
-{
-    (void)failures;
-    signal_eot();
-    while (1) { }
-}
-
-void HardFault_Handler(void)
-{
-    printf("HardFault\r\n");
-    signal_eot();
-    while (1) { }
-}

--- a/assets/templates/common/validate.j2
+++ b/assets/templates/common/validate.j2
@@ -64,6 +64,25 @@ static inline int helia_test_finish_validation(int failures)
 #define HELIA_VALIDATE_RETURN_FAILURES(failures) \
     return helia_test_finish_validation((failures))
 
+/*
+ * Compile-time guard (issue #54): the integer validators cast elements to
+ * long long, which silently truncates float outputs (|v| < 1 becomes 0 on
+ * both sides and always "matches"). If a generator regression ever routes a
+ * float-typed output into an integer validator again, fail the BUILD instead
+ * of silently passing forever. __fp16 is included only where the target
+ * defines an IEEE half type, which is every configuration that can compile
+ * float16 test data in the first place.
+ */
+#if defined(__ARM_FP16_FORMAT_IEEE) || defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC)
+#define HELIA_ELEM_IS_FLOAT(expr) _Generic((expr), float: 1, double: 1, __fp16: 1, default: 0)
+#else
+#define HELIA_ELEM_IS_FLOAT(expr) _Generic((expr), float: 1, double: 1, default: 0)
+#endif
+#define HELIA_ASSERT_INT_VALIDATOR_INPUT(arr) \
+    _Static_assert(!HELIA_ELEM_IS_FLOAT((arr)[0]), \
+                   "integer validator applied to float outputs: validation-mode coercion " \
+                   "(helia-core-tester issue #54); float outputs need the FLOAT validator")
+
 {% if "float" in validation_helpers %}
 static inline double helia_test_float_tolerance(double expected, double atol, double rtol)
 {
@@ -74,6 +93,8 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
 {% if "exact_int" in validation_helpers %}
 #define HELIA_VALIDATE_EXACT_INTS(actual, expected, size, max_reports, failures) \
     do { \
+        HELIA_ASSERT_INT_VALIDATOR_INPUT(actual); \
+        HELIA_ASSERT_INT_VALIDATOR_INPUT(expected); \
         for (int helia_i = 0; helia_i < (size); ++helia_i) { \
             long long helia_act_val = (long long)((actual)[helia_i]); \
             long long helia_exp_val = (long long)((expected)[helia_i]); \
@@ -90,6 +111,8 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
 {% if "tolerant_int" in validation_helpers %}
 #define HELIA_VALIDATE_TOLERANT_INTS(actual, expected, size, tolerance, max_reports, failures) \
     do { \
+        HELIA_ASSERT_INT_VALIDATOR_INPUT(actual); \
+        HELIA_ASSERT_INT_VALIDATOR_INPUT(expected); \
         for (int helia_i = 0; helia_i < (size); ++helia_i) { \
             long long helia_act_val = (long long)((actual)[helia_i]); \
             long long helia_exp_val = (long long)((expected)[helia_i]); \

--- a/assets/templates/common/validate.j2
+++ b/assets/templates/common/validate.j2
@@ -74,8 +74,14 @@ static inline int helia_test_finish_validation(int failures)
  * defines an IEEE half type, which is every configuration that can compile
  * float16 test data in the first place.
  */
-#if defined(__ARM_FP16_FORMAT_IEEE) || defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC)
+#if (defined(__ARM_FP16_FORMAT_IEEE) || defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC)) && defined(__FLT16_MAX__)
+/* __fp16 and _Float16 are distinct types on GCC/Clang Arm targets; block both
+ * (float16_t may typedef either depending on toolchain/host configuration). */
+#define HELIA_ELEM_IS_FLOAT(expr) _Generic((expr), float: 1, double: 1, __fp16: 1, _Float16: 1, default: 0)
+#elif defined(__ARM_FP16_FORMAT_IEEE) || defined(__ARM_FEATURE_FP16_SCALAR_ARITHMETIC)
 #define HELIA_ELEM_IS_FLOAT(expr) _Generic((expr), float: 1, double: 1, __fp16: 1, default: 0)
+#elif defined(__FLT16_MAX__)
+#define HELIA_ELEM_IS_FLOAT(expr) _Generic((expr), float: 1, double: 1, _Float16: 1, default: 0)
 #else
 #define HELIA_ELEM_IS_FLOAT(expr) _Generic((expr), float: 1, double: 1, default: 0)
 #endif

--- a/assets/templates/common/validate.j2
+++ b/assets/templates/common/validate.j2
@@ -64,6 +64,7 @@ static inline int helia_test_finish_validation(int failures)
 #define HELIA_VALIDATE_RETURN_FAILURES(failures) \
     return helia_test_finish_validation((failures))
 
+{% if "exact_int" in validation_helpers or "tolerant_int" in validation_helpers %}
 /*
  * Compile-time guard (issue #54): the integer validators cast elements to
  * long long, which silently truncates float outputs (|v| < 1 becomes 0 on
@@ -82,6 +83,7 @@ static inline int helia_test_finish_validation(int failures)
     _Static_assert(!HELIA_ELEM_IS_FLOAT((arr)[0]), \
                    "integer validator applied to float outputs: validation-mode coercion " \
                    "(helia-core-tester issue #54); float outputs need the FLOAT validator")
+{% endif %}
 
 {% if "float" in validation_helpers %}
 static inline double helia_test_float_tolerance(double expected, double atol, double rtol)

--- a/helia_core_tester/generation/ops/ActivationFunctions/clamp.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/clamp.py
@@ -87,7 +87,6 @@ class OpClamp(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'act_min': int(act_min),

--- a/helia_core_tester/generation/ops/ActivationFunctions/leaky_relu.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/leaky_relu.py
@@ -162,7 +162,6 @@ class OpLeakyRelu(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'input_offset': int(input_zp),

--- a/helia_core_tester/generation/ops/ActivationFunctions/logistic.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/logistic.py
@@ -238,7 +238,6 @@ class OpLogistic(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'output_size': output_size,

--- a/helia_core_tester/generation/ops/ActivationFunctions/nn_activation_float.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/nn_activation_float.py
@@ -163,7 +163,6 @@ class OpNNActivationFloat(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "size": int(np.prod(input_shape)),
             "input_data_array": builder.format_array_as_c_literal(input_data),
             "expected_output_array": builder.format_array_as_c_literal(output_data),

--- a/helia_core_tester/generation/ops/ActivationFunctions/nn_activation_s16.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/nn_activation_s16.py
@@ -119,7 +119,6 @@ class OpNNActivationS16(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'left_shift': int(left_shift),

--- a/helia_core_tester/generation/ops/ActivationFunctions/prelu.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/prelu.py
@@ -198,7 +198,6 @@ class OpPReLU(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'alpha_dims': alpha_dims,
             'output_dims': output_dims,
@@ -338,7 +337,6 @@ class OpPReLU(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'alpha_dims': alpha_dims,
             'output_dims': output_dims,
@@ -604,7 +602,6 @@ class OpPReLU(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'alpha_dims': alpha_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/ActivationFunctions/prelu_scalar.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/prelu_scalar.py
@@ -194,7 +194,6 @@ class OpPReLUScalar(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "num_pixels": num_pixels,
             "scalar_array": builder.format_array_as_c_literal(scalar_q.reshape(-1)),
             "alpha_array": builder.format_array_as_c_literal(alpha_q.reshape(-1)),

--- a/helia_core_tester/generation/ops/ActivationFunctions/relu.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/relu.py
@@ -127,7 +127,6 @@ class OpRelu(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'input_offset': int(input_zp),

--- a/helia_core_tester/generation/ops/ActivationFunctions/relu6.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/relu6.py
@@ -174,7 +174,6 @@ class OpRelu6(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'input_offset': int(input_zp),

--- a/helia_core_tester/generation/ops/ActivationFunctions/tanh.py
+++ b/helia_core_tester/generation/ops/ActivationFunctions/tanh.py
@@ -232,7 +232,6 @@ class OpTanh(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'output_size': output_size,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
@@ -162,7 +162,6 @@ class OpAbs(OperationBase):
 
         context = {
             "name": name,
-            "prefix": name,
             "input_dims": input_dims,
             "output_dims": output_dims,
             "input_offset": -int(input_zp),

--- a/helia_core_tester/generation/ops/BasicMathFunctions/add.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/add.py
@@ -242,7 +242,6 @@ class OpAdd(BinaryBasicMathBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input1_dims': input1_dims,
             'input2_dims': input2_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/argmax.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/argmax.py
@@ -130,7 +130,6 @@ class OpArgMax(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'axis': axis,
             'input_data_array': input_array_str,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/argmin.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/argmin.py
@@ -130,7 +130,6 @@ class OpArgMin(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'axis': axis,
             'input_data_array': input_array_str,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/mean.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/mean.py
@@ -218,7 +218,6 @@ class OpMean(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'axis_dims': axis_dims_cmsis,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/minmax.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/minmax.py
@@ -223,7 +223,6 @@ class OpMinMax(BinaryBasicMathBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input1_dims': input1_dims,
             'input2_dims': input2_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/mul.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/mul.py
@@ -192,7 +192,6 @@ class OpMul(BinaryBasicMathBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input1_dims': input1_dims,
             'input2_dims': input2_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/reduce_max.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/reduce_max.py
@@ -142,7 +142,6 @@ class OpReduceMax(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'axis_dims': axis_dims_cmsis,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/reduce_min.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/reduce_min.py
@@ -142,7 +142,6 @@ class OpReduceMin(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'axis_dims': axis_dims_cmsis,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/reduce_sum.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/reduce_sum.py
@@ -114,7 +114,6 @@ class OpReduceSum(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'axis_dims': axis_dims_cmsis,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/rsqrt.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/rsqrt.py
@@ -213,7 +213,6 @@ class OpRsqrt(OperationBase):
 
         context = {
             "name": name,
-            "prefix": name,
             "call_style": call_style,
             "input_dims": input_dims,
             "output_dims": output_dims,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/sqrt.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/sqrt.py
@@ -249,7 +249,6 @@ class OpSqrt(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'input_data_array': input_array_str,
             'expected_output_array': expected_output_array_str,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/squared_difference.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/squared_difference.py
@@ -321,7 +321,6 @@ class OpSquaredDifference(BinaryBasicMathBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input1_dims': input1_dims,
             'input2_dims': input2_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/sub.py
@@ -248,7 +248,6 @@ class OpSub(BinaryBasicMathBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input1_dims': input1_dims,
             'input2_dims': input2_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/BroadcastFunctions/broadcast_to.py
+++ b/helia_core_tester/generation/ops/BroadcastFunctions/broadcast_to.py
@@ -133,7 +133,6 @@ class OpBroadcastTo(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             'name': name,
-            'prefix': name,
             'rank': params_rank,
             'input_shape': input_shape,
             'output_shape': output_shape,

--- a/helia_core_tester/generation/ops/ConcatenationFunctions/concatenation.py
+++ b/helia_core_tester/generation/ops/ConcatenationFunctions/concatenation.py
@@ -301,7 +301,6 @@ class OpConcatenation(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'output_dims': output_dims,
             'output_rank': output_rank,
             'num_inputs': num_inputs,

--- a/helia_core_tester/generation/ops/ConcatenationFunctions/split.py
+++ b/helia_core_tester/generation/ops/ConcatenationFunctions/split.py
@@ -162,7 +162,6 @@ class OpSplit(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'input_dims_count': len(input_shape),
             'axis': axis,

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
@@ -636,7 +636,6 @@ class OpConvolve(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'filter_dims': filter_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
@@ -101,9 +101,14 @@ class OpConvolve(OperationBase):
         # bias-add path completely untested. Use a small nonzero uniform
         # bias, deterministic from the case seed, so real bias data flows
         # through the golden and the kernel call.
+        # Float cases only: the same Keras model also feeds the QUANTIZED
+        # pipeline, so an ungated nonzero bias would silently perturb every
+        # int8/int16 conv golden (54 cases -- caught by adversarial review).
+        # Int-suite bias enrichment is a separate, deliberate change.
+        _case_is_float = str(self.tensor_dtype("input", default="S8")).upper() in {"FP32", "FP16"}
         bias_initializer = (
             tf.keras.initializers.RandomUniform(minval=-0.25, maxval=0.25, seed=self.seed)
-            if use_bias else 'zeros'
+            if (use_bias and _case_is_float) else 'zeros'
         )
 
         conv = tf.keras.layers.Conv2D(

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
@@ -93,6 +93,19 @@ class OpConvolve(OperationBase):
             name='input'
         )
         
+        use_bias = self.desc.get('use_bias', True)
+        # A zero bias_initializer produces an all-zero bias tensor, which the
+        # TFLite converter's constant-folding optimizer strips from the
+        # FLOAT (non-quantized) graph entirely -- the generated CMSIS-NN
+        # test then calls the kernel with a NULL bias pointer, leaving the
+        # bias-add path completely untested. Use a small nonzero uniform
+        # bias, deterministic from the case seed, so real bias data flows
+        # through the golden and the kernel call.
+        bias_initializer = (
+            tf.keras.initializers.RandomUniform(minval=-0.25, maxval=0.25, seed=self.seed)
+            if use_bias else 'zeros'
+        )
+
         conv = tf.keras.layers.Conv2D(
             filters=output_filters,
             kernel_size=tuple(filter_shape[0:2]),
@@ -100,10 +113,10 @@ class OpConvolve(OperationBase):
             dilation_rate=tuple(dilation),
             padding=padding,
             groups=groups,
-            use_bias=self.desc.get('use_bias', True),
+            use_bias=use_bias,
             activation=act,
             kernel_initializer=tf.keras.initializers.GlorotUniform(seed=1234),
-            bias_initializer='zeros',
+            bias_initializer=bias_initializer,
             name='conv_2d'
         )(x)
         
@@ -278,6 +291,7 @@ class OpConvolve(OperationBase):
         
         conv_op_index = 0
         bts_op_index = None
+        hoisted_bias_data = None
         try:
             from ai_edge_litert import schema_py_generated as litert
 
@@ -289,9 +303,51 @@ class OpConvolve(OperationBase):
                     found_conv = True
                 if opcode.builtinCode == litert.BuiltinOperator.BATCH_TO_SPACE_ND:
                     bts_op_index = i
+
+            # Dilated graphs lower to SpaceToBatchND -> Conv2D -> BatchToSpaceND.
+            # TF's MLIR converter hoists the bias-add out of CONV_2D in this
+            # pattern: the CONV_2D op keeps only a zero-filled placeholder
+            # bias, and the real bias is applied via a separate ADD op after
+            # BatchToSpaceND. If we naively pull "biases" from the CONV_2D
+            # op's own inputs (as done above via get_operator_tensors_from_litert),
+            # we get that zero placeholder instead of the bias the golden
+            # output was actually computed with. Find the hoisted bias, if
+            # this pattern is present, so the CMSIS kernel is called with the
+            # same bias the golden reflects.
+            #
+            # Scoped to float kernels only: the same ADD-after-BatchToSpaceND
+            # shape exists in quantized (S8/S16) graphs too, but there the
+            # hoisted ADD operates in the quantized output domain (its
+            # operand is not a plain int32 accumulator bias), so reusing this
+            # extraction for quantized dtypes would silently substitute the
+            # wrong tensor. Quantized dilated-conv bias handling is out of
+            # scope here and is left untouched.
+            if float_kernel and bts_op_index is not None:
+                from helia_core_tester.generation.utils.litert_utils import get_tensor_data_from_litert
+
+                bts_outs = subgraph.operators[bts_op_index].outputs
+                bts_output_idx = int(bts_outs[0]) if bts_outs is not None and len(bts_outs) > 0 else None
+                if bts_output_idx is not None:
+                    for i in range(bts_op_index + 1, len(subgraph.operators)):
+                        op = subgraph.operators[i]
+                        opcode = model.operatorCodes[op.opcodeIndex]
+                        if opcode.builtinCode != litert.BuiltinOperator.ADD:
+                            continue
+                        if bts_output_idx not in list(op.inputs):
+                            continue
+                        for input_idx in op.inputs:
+                            if int(input_idx) == bts_output_idx:
+                                continue
+                            candidate = subgraph.tensors[int(input_idx)]
+                            candidate_data = get_tensor_data_from_litert(candidate, model)
+                            if candidate_data is not None and candidate_data.ndim == 1:
+                                hoisted_bias_data = candidate_data
+                                break
+                        break
         except Exception:
             conv_op_index = 0
             bts_op_index = None
+            hoisted_bias_data = None
 
         op_tensors = get_operator_tensors_from_litert(model, subgraph, conv_op_index)
         
@@ -359,6 +415,13 @@ class OpConvolve(OperationBase):
         # Extract weights and biases from LiteRT
         weights = op_tensors['weights']
         biases = op_tensors['biases']
+        if hoisted_bias_data is not None:
+            # See the SpaceToBatchND/BatchToSpaceND comment above: this
+            # dilated-conv graph applies its real bias via a post-BatchToSpace
+            # ADD op, not inside CONV_2D. Use that bias instead of the zero
+            # placeholder CONV_2D carries, so the kernel call matches the
+            # golden's bias.
+            biases = hoisted_bias_data
         weight_dtype = str(self.desc.get("weight_dtype", "S8")).upper()
         if weight_dtype == "S4":
             from helia_core_tester.generation.utils.litert_utils import get_tensor_data_packed_from_litert

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/convolve.py
@@ -345,7 +345,19 @@ class OpConvolve(OperationBase):
                                 continue
                             candidate = subgraph.tensors[int(input_idx)]
                             candidate_data = get_tensor_data_from_litert(candidate, model)
-                            if candidate_data is not None and candidate_data.ndim == 1:
+                            # Adversarial-review hardening: the quantized graph's
+                            # hoisted ADD operand clears the opcode/constness/ndim
+                            # gates too (dtype int16, quantized-output domain) --
+                            # only dtype and exact per-channel length make this
+                            # extraction safe. A broadcast scalar (shape (1,))
+                            # would otherwise be emitted and read out of bounds
+                            # by the kernel (output_dims.c elements).
+                            if (
+                                candidate_data is not None
+                                and candidate_data.ndim == 1
+                                and candidate_data.dtype.kind == "f"
+                                and candidate_data.shape[0] == int(self.desc["filter_shape"][3])
+                            ):
                                 hoisted_bias_data = candidate_data
                                 break
                         break

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/depthwise_conv.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/depthwise_conv.py
@@ -724,7 +724,6 @@ class OpDepthwiseConv(OperationBase):
 
             context = {
                 'name': name,
-                'prefix': name,
                 'input_dims': input_dims,
                 'filter_dims': filter_dims,
                 'output_dims': output_dims,
@@ -997,7 +996,6 @@ class OpDepthwiseConv(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'filter_dims': filter_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/ConvolutionFunctions/transpose_conv.py
+++ b/helia_core_tester/generation/ops/ConvolutionFunctions/transpose_conv.py
@@ -397,7 +397,6 @@ class OpTransposeConv(OperationBase):
 
             context = {
                 'name': name,
-                'prefix': name,
                 'input_dims': input_dims,
                 'filter_dims': filter_dims,
                 'output_dims': output_dims,
@@ -593,7 +592,6 @@ class OpTransposeConv(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'filter_dims': filter_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/DynamicUpdateSliceFunctions/dynamic_update_slice.py
+++ b/helia_core_tester/generation/ops/DynamicUpdateSliceFunctions/dynamic_update_slice.py
@@ -145,7 +145,6 @@ class OpDynamicUpdateSlice(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "rank": params_rank,
             "operand_shape": operand_shape,
             "update_shape": update_shape,

--- a/helia_core_tester/generation/ops/FullyConnectedFunctions/batch_matmul.py
+++ b/helia_core_tester/generation/ops/FullyConnectedFunctions/batch_matmul.py
@@ -316,7 +316,6 @@ class OpBatchMatMul(OperationBase):
 
             context = {
                 'name': name,
-                'prefix': name,
                 'input_lhs_dims': input_lhs_dims,
                 'input_rhs_dims': input_rhs_dims,
                 'output_dims': output_dims,
@@ -453,7 +452,6 @@ class OpBatchMatMul(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_lhs_dims': input_lhs_dims,
             'input_rhs_dims': input_rhs_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
+++ b/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
@@ -64,9 +64,12 @@ class OpFullyConnected(OperationBase):
         # pointer, leaving the bias-add path completely untested. Use a
         # small nonzero uniform bias, deterministic from the case seed, so
         # real bias data flows through the golden and the kernel call.
+        # Float cases only: the same Keras model also feeds the QUANTIZED
+        # pipeline (see convolve.py) -- keep int FC goldens byte-identical.
+        _case_is_float = str(self.tensor_dtype("input", default="S8")).upper() in {"FP32", "FP16"}
         bias_initializer = (
             keras.initializers.RandomUniform(minval=-0.25, maxval=0.25, seed=self.seed)
-            if use_bias else 'zeros'
+            if (use_bias and _case_is_float) else 'zeros'
         )
 
         # Dense layer without activation (we'll apply activation separately if needed)

--- a/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
+++ b/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
@@ -629,7 +629,6 @@ class OpFullyConnected(OperationBase):
 
             context = {
                 'name': name,
-                'prefix': name,
                 'input_dims': input_dims,
                 'filter_dims': filter_dims,
                 'output_dims': output_dims,
@@ -955,7 +954,6 @@ class OpFullyConnected(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'filter_dims': filter_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
+++ b/helia_core_tester/generation/ops/FullyConnectedFunctions/fully_connected.py
@@ -57,8 +57,26 @@ class OpFullyConnected(OperationBase):
             inputs = keras.layers.Input(shape=(input_features,), batch_size=batch_size, name='input')
             x = inputs
         
+        # A zero bias_initializer (Dense's default) produces an all-zero bias
+        # tensor, which the TFLite converter's constant-folding optimizer
+        # strips from the FLOAT (non-quantized) graph entirely -- the
+        # generated CMSIS-NN test then calls the kernel with a NULL bias
+        # pointer, leaving the bias-add path completely untested. Use a
+        # small nonzero uniform bias, deterministic from the case seed, so
+        # real bias data flows through the golden and the kernel call.
+        bias_initializer = (
+            keras.initializers.RandomUniform(minval=-0.25, maxval=0.25, seed=self.seed)
+            if use_bias else 'zeros'
+        )
+
         # Dense layer without activation (we'll apply activation separately if needed)
-        x = keras.layers.Dense(output_units, activation=None, use_bias=use_bias, name='dense')(x)
+        x = keras.layers.Dense(
+            output_units,
+            activation=None,
+            use_bias=use_bias,
+            bias_initializer=bias_initializer,
+            name='dense'
+        )(x)
         
         # Apply activation if specified
         if activation_str == 'RELU':

--- a/helia_core_tester/generation/ops/GatherFunctions/gather.py
+++ b/helia_core_tester/generation/ops/GatherFunctions/gather.py
@@ -125,7 +125,6 @@ class OpGather(OperationBase):
 
         context = {
             "name": name,
-            "prefix": name,
             "kernel_fn": kernel_info["kernel_fn"],
             "input_dtype": kernel_info["input_c_type"],
             "output_dtype": kernel_info["output_c_type"],

--- a/helia_core_tester/generation/ops/GatherFunctions/gather_nd.py
+++ b/helia_core_tester/generation/ops/GatherFunctions/gather_nd.py
@@ -173,7 +173,6 @@ class OpGatherND(OperationBase):
 
         context = {
             "name": name,
-            "prefix": name,
             "kernel_fn": kernel_info["kernel_fn"],
             "input_dtype": kernel_info["input_c_type"],
             "output_dtype": kernel_info["output_c_type"],

--- a/helia_core_tester/generation/ops/LSTMFunctions/gru_unidirectional.py
+++ b/helia_core_tester/generation/ops/LSTMFunctions/gru_unidirectional.py
@@ -191,7 +191,6 @@ class OpGRUUnidirectional(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "data_dtype": data_dtype,
             "kernel_fn": kernel_fn,
             "gru_params_type": gru_params_type,

--- a/helia_core_tester/generation/ops/LSTMFunctions/lstm_unidirectional.py
+++ b/helia_core_tester/generation/ops/LSTMFunctions/lstm_unidirectional.py
@@ -260,6 +260,7 @@ class OpLSTMUnidirectional(OperationBase):
                 "name": name,
                 "prefix": name,
                 "data_dtype": data_dtype,
+                "output_dtype": data_dtype,
                 "kernel_fn": kernel_fn,
                 "lstm_params_type": lstm_params_type,
                 "lstm_context_type": lstm_context_type,

--- a/helia_core_tester/generation/ops/LSTMFunctions/lstm_unidirectional.py
+++ b/helia_core_tester/generation/ops/LSTMFunctions/lstm_unidirectional.py
@@ -258,7 +258,6 @@ class OpLSTMUnidirectional(OperationBase):
             builder = TemplateContextBuilder()
             context = {
                 "name": name,
-                "prefix": name,
                 "data_dtype": data_dtype,
                 "output_dtype": data_dtype,
                 "kernel_fn": kernel_fn,

--- a/helia_core_tester/generation/ops/NNSupportFunctions/batch_norm.py
+++ b/helia_core_tester/generation/ops/NNSupportFunctions/batch_norm.py
@@ -51,7 +51,6 @@ class OpBatchNorm(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "input_dims": builder.nhwc_to_cmsis_dims(input_shape),
             "input_data_array": builder.format_array_as_c_literal(input_data),
             "scale_array": builder.format_array_as_c_literal(scale),

--- a/helia_core_tester/generation/ops/NNSupportFunctions/requantize.py
+++ b/helia_core_tester/generation/ops/NNSupportFunctions/requantize.py
@@ -78,7 +78,6 @@ class OpRequantize(QuantizationFamilyBase):
 
         context = {
             "name": name,
-            "prefix": name,
             "input_size": size,
             "input_shape_array": builder.format_array_as_c_literal(np.array(input_shape, dtype=np.int32)),
             "input_data_array": builder.format_array_as_c_literal(input_q),

--- a/helia_core_tester/generation/ops/PadFunctions/mirror_pad.py
+++ b/helia_core_tester/generation/ops/PadFunctions/mirror_pad.py
@@ -96,7 +96,6 @@ class OpMirrorPad(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "rank": rank,
             "input_shape": input_shape,
             "output_shape": output_shape,

--- a/helia_core_tester/generation/ops/PadFunctions/pad.py
+++ b/helia_core_tester/generation/ops/PadFunctions/pad.py
@@ -156,7 +156,6 @@ class OpPad(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'pre_pad_dims': pre_pad_dims,

--- a/helia_core_tester/generation/ops/QuantizationFunctions/dequantize.py
+++ b/helia_core_tester/generation/ops/QuantizationFunctions/dequantize.py
@@ -202,7 +202,6 @@ class OpDequantize(QuantizationFamilyBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_size': input_size,
             'zero_point': int(input_zp),
             'scale': float(input_scale),

--- a/helia_core_tester/generation/ops/QuantizationFunctions/quantize.py
+++ b/helia_core_tester/generation/ops/QuantizationFunctions/quantize.py
@@ -228,7 +228,6 @@ class OpQuantize(QuantizationFamilyBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_size': input_size,
             'zero_point': int(output_zp),
             'scale': float(output_scale),

--- a/helia_core_tester/generation/ops/ReshapeFunctions/batch_to_space_nd.py
+++ b/helia_core_tester/generation/ops/ReshapeFunctions/batch_to_space_nd.py
@@ -110,7 +110,6 @@ class OpBatchToSpaceND(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'block_shape': block_shape,

--- a/helia_core_tester/generation/ops/ReshapeFunctions/depth_to_space.py
+++ b/helia_core_tester/generation/ops/ReshapeFunctions/depth_to_space.py
@@ -76,7 +76,6 @@ class OpDepthToSpace(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'block_size': int(self.desc.get('block_size', 1)),

--- a/helia_core_tester/generation/ops/ReshapeFunctions/reshape.py
+++ b/helia_core_tester/generation/ops/ReshapeFunctions/reshape.py
@@ -122,7 +122,6 @@ class OpReshape(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'total_size': total_size,

--- a/helia_core_tester/generation/ops/ReshapeFunctions/resize_nearest_neighbor.py
+++ b/helia_core_tester/generation/ops/ReshapeFunctions/resize_nearest_neighbor.py
@@ -123,7 +123,6 @@ class OpResizeNearestNeighbor(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'output_size_dims': size_dims,

--- a/helia_core_tester/generation/ops/ReshapeFunctions/space_to_batch_nd.py
+++ b/helia_core_tester/generation/ops/ReshapeFunctions/space_to_batch_nd.py
@@ -102,7 +102,6 @@ class OpSpaceToBatchND(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'block_shape': block_shape,

--- a/helia_core_tester/generation/ops/ReshapeFunctions/space_to_depth.py
+++ b/helia_core_tester/generation/ops/ReshapeFunctions/space_to_depth.py
@@ -77,7 +77,6 @@ class OpSpaceToDepth(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'block_size': int(self.desc.get('block_size', 1)),

--- a/helia_core_tester/generation/ops/ReverseSequenceFunctions/reverse_sequence.py
+++ b/helia_core_tester/generation/ops/ReverseSequenceFunctions/reverse_sequence.py
@@ -102,7 +102,6 @@ class OpReverseSequence(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "rank": rank,
             "input_shape": input_shape,
             "seq_lengths": seq_lengths,

--- a/helia_core_tester/generation/ops/SVDFunctions/svdf.py
+++ b/helia_core_tester/generation/ops/SVDFunctions/svdf.py
@@ -269,6 +269,7 @@ class OpSVDF(OperationBase):
                 "prefix": name,
                 "kernel_fn": kernel_fn,
                 "data_dtype": data_dtype,
+                "output_dtype": data_dtype,
                 "svdf_params_type": svdf_params_type,
                 "input_batches": input_batches,
                 "input_height": input_height,

--- a/helia_core_tester/generation/ops/SVDFunctions/svdf.py
+++ b/helia_core_tester/generation/ops/SVDFunctions/svdf.py
@@ -266,7 +266,6 @@ class OpSVDF(OperationBase):
             builder = TemplateContextBuilder()
             context = {
                 "name": name,
-                "prefix": name,
                 "kernel_fn": kernel_fn,
                 "data_dtype": data_dtype,
                 "output_dtype": data_dtype,
@@ -391,7 +390,6 @@ class OpSVDF(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "kernel_fn": kernel_fn,
             "has_ctx": has_ctx,
             "input_batches": input_batches,
@@ -425,6 +423,9 @@ class OpSVDF(OperationBase):
             "state_init_array": builder.format_array_as_c_literal(state_init),
             "output_ref_array": builder.format_array_as_c_literal(expected_output),
             "bias_array": builder.format_array_as_c_literal(bias) if bias is not None else "",
+            # svdf.c.j2 is the only template that allocates scratch buffers with
+            # malloc/free; gate the shared runtime_common.j2 stdlib.h include on it.
+            "needs_stdlib": True,
         }
 
         includes_api_dir = output_dir / "includes"

--- a/helia_core_tester/generation/ops/ScatterFunctions/scatter_nd.py
+++ b/helia_core_tester/generation/ops/ScatterFunctions/scatter_nd.py
@@ -118,7 +118,6 @@ class OpScatterNd(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "rank": len(output_shape),
             "output_shape": output_shape,
             "num_updates": num_updates,

--- a/helia_core_tester/generation/ops/SelectFunctions/select_v2.py
+++ b/helia_core_tester/generation/ops/SelectFunctions/select_v2.py
@@ -111,7 +111,6 @@ class OpSelectV2(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "rank": rank,
             "output_shape": output_shape,
             "condition_shape": condition_shape,

--- a/helia_core_tester/generation/ops/SelectFunctions/where.py
+++ b/helia_core_tester/generation/ops/SelectFunctions/where.py
@@ -91,7 +91,6 @@ class OpWhere(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             "name": name,
-            "prefix": name,
             "rank": rank,
             "input_shape": input_shape,
             "total_elements": total_elements,

--- a/helia_core_tester/generation/ops/SoftmaxFunctions/softmax.py
+++ b/helia_core_tester/generation/ops/SoftmaxFunctions/softmax.py
@@ -463,7 +463,6 @@ class OpSoftmax(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'num_rows': num_rows,

--- a/helia_core_tester/generation/ops/StridedSliceFunctions/strided_slice.py
+++ b/helia_core_tester/generation/ops/StridedSliceFunctions/strided_slice.py
@@ -348,7 +348,6 @@ class OpStridedSlice(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'begin_dims': begin_dims,

--- a/helia_core_tester/generation/ops/TesterExtensions/squeeze.py
+++ b/helia_core_tester/generation/ops/TesterExtensions/squeeze.py
@@ -218,7 +218,6 @@ class OpSqueeze(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'total_size': total_size,

--- a/helia_core_tester/generation/ops/TileFunctions/tile.py
+++ b/helia_core_tester/generation/ops/TileFunctions/tile.py
@@ -95,7 +95,6 @@ class OpTile(OperationBase):
         builder = TemplateContextBuilder()
         context = {
             'name': name,
-            'prefix': name,
             'rank': rank,
             'input_shape': input_shape,
             'output_shape': output_shape,

--- a/helia_core_tester/generation/ops/TransposeFunctions/transpose.py
+++ b/helia_core_tester/generation/ops/TransposeFunctions/transpose.py
@@ -262,7 +262,6 @@ class OpTranspose(OperationBase):
 
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'num_dims': num_dims,

--- a/helia_core_tester/generation/ops/_shared/comparison_base.py
+++ b/helia_core_tester/generation/ops/_shared/comparison_base.py
@@ -147,7 +147,6 @@ class ComparisonFamilyBase(OperationBase):
 
         context = {
             "name": name,
-            "prefix": name,
             "input_1_dims": input_1_dims,
             "input_2_dims": input_2_dims,
             "output_dims": output_dims,

--- a/helia_core_tester/generation/ops/_shared/hard_swish_base.py
+++ b/helia_core_tester/generation/ops/_shared/hard_swish_base.py
@@ -463,7 +463,6 @@ class HardSwishFamilyBase(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'output_dims': output_dims,
             'input_offset': int(input_zp),

--- a/helia_core_tester/generation/ops/_shared/pool_base.py
+++ b/helia_core_tester/generation/ops/_shared/pool_base.py
@@ -236,7 +236,6 @@ class PoolFamilyBase(OperationBase):
         # Build template context
         context = {
             'name': name,
-            'prefix': name,
             'input_dims': input_dims,
             'filter_dims': filter_dims,
             'output_dims': output_dims,

--- a/helia_core_tester/generation/utils/lstm_data.py
+++ b/helia_core_tester/generation/utils/lstm_data.py
@@ -626,7 +626,6 @@ def build_lstm_context(
 
     return {
         "name": name,
-        "prefix": name,
         "dataset": dataset,
         "macro_prefix": macro_prefix,
         "data_prefix": data_prefix,

--- a/helia_core_tester/generation/utils/template_context.py
+++ b/helia_core_tester/generation/utils/template_context.py
@@ -140,20 +140,31 @@ class TemplateContextBuilder:
         explicit = context.get("validation_mode")
         if explicit:
             return str(explicit).strip().lower()
+        # Output dtype wins over the template-path allowlists: the allowlists
+        # exist to pick the right INT comparison for shared int templates, and
+        # must never route a float-typed output into an integer comparison
+        # (the (long long) cast truncates |v| < 1 to 0 on both sides, making
+        # the comparison vacuous — issue #54). Float descriptors reusing an
+        # int template get a real float comparison; int descriptors are
+        # unaffected and fall through to the allowlists as before.
+        # data_dtype is the fallback because several generators (LSTM, SVDF)
+        # historically set only that key; an op whose output dtype differs
+        # from its data dtype (e.g. Quantize) must set output_dtype explicitly.
+        output_dtype = str(
+            context.get("output_dtype") or context.get("data_dtype") or ""
+        ).strip().lower()
+        if output_dtype == "bool":
+            return "bool"
         if normalized_path in cls._BOOL_VALIDATION_TEMPLATES:
             return "bool"
+        if "float" in output_dtype:
+            return "float"
         if normalized_path in cls._FLOAT_VALIDATION_TEMPLATES:
             return "float"
         if normalized_path in cls._EXACT_INT_VALIDATION_TEMPLATES:
             return "exact_int"
         if normalized_path in cls._TOLERANT_INT_VALIDATION_TEMPLATES:
             return "tolerant_int"
-
-        output_dtype = str(context.get("output_dtype", "")).strip().lower()
-        if output_dtype == "bool":
-            return "bool"
-        if "float" in output_dtype:
-            return "float"
         return "exact_int"
 
     @classmethod
@@ -256,6 +267,19 @@ class TemplateContextBuilder:
     ) -> Dict[str, Any]:
         resolved = dict(context)
         mode = cls.infer_validation_mode(template_path, resolved)
+        # Invariant (issue #54): a float-typed output must never be validated
+        # by an integer comparison — the (long long) cast makes it vacuous.
+        # This also rejects coercion via an explicit validation_mode override.
+        output_dtype = str(
+            resolved.get("output_dtype") or resolved.get("data_dtype") or ""
+        ).strip().lower()
+        if "float" in output_dtype and mode in ("exact_int", "tolerant_int"):
+            raise ValueError(
+                f"Validation-mode coercion: template '{template_path}' resolved "
+                f"integer validation mode '{mode}' for float output dtype "
+                f"'{output_dtype}'. Float outputs require a float comparison "
+                f"(see helia-core-tester issue #54)."
+            )
         resolved.setdefault("validation_mode", mode)
         resolved.setdefault("validation_mode_token", mode.upper())
         resolved.setdefault(

--- a/helia_core_tester/generation/utils/template_context.py
+++ b/helia_core_tester/generation/utils/template_context.py
@@ -273,12 +273,14 @@ class TemplateContextBuilder:
         output_dtype = str(
             resolved.get("output_dtype") or resolved.get("data_dtype") or ""
         ).strip().lower()
-        if "float" in output_dtype and mode in ("exact_int", "tolerant_int"):
+        if "float" in output_dtype and mode in ("exact_int", "tolerant_int", "bool", "none"):
             raise ValueError(
                 f"Validation-mode coercion: template '{template_path}' resolved "
-                f"integer validation mode '{mode}' for float output dtype "
-                f"'{output_dtype}'. Float outputs require a float comparison "
-                f"(see helia-core-tester issue #54)."
+                f"validation mode '{mode}' for float output dtype "
+                f"'{output_dtype}'. Float outputs require a float comparison; "
+                f"'none' recreates the #54 end state (no comparison at all). "
+                f"Status-only fault templates should simply not invoke output "
+                f"validation rather than coercing the mode."
             )
         resolved.setdefault("validation_mode", mode)
         resolved.setdefault("validation_mode_token", mode.upper())

--- a/helia_core_tester/tests/test_template_standalone_contract.py
+++ b/helia_core_tester/tests/test_template_standalone_contract.py
@@ -40,7 +40,7 @@ def test_all_c_templates_use_standalone_harness_contract() -> None:
         assert "TEST_ASSERT" not in text, path
         assert '{% include "common/standalone/runtime_common.j2" %}' in text, path
         assert '{% include "common/standalone/main.j2" %}' in text, path
-        assert "int32_t {{ prefix }}_{{ name }}_test_case_run(void)" in text, path
+        assert "int32_t {{ name }}_test_case_run(void)" in text, path
         assert (
             "HELIA_VALIDATE_STATUS(" in text
             or "HELIA_VALIDATE_EXPECTED_STATUS(" in text
@@ -59,7 +59,7 @@ def test_all_c_templates_keep_inline_validation_out_of_templates() -> None:
         assert 'printf("%d Failures' not in text, path
         assert "compare_output(" not in text, path
 
-        marker = "int32_t {{ prefix }}_{{ name }}_test_case_run(void)"
+        marker = "int32_t {{ name }}_test_case_run(void)"
         start = text.find(marker)
         assert start >= 0, path
         end = text.find('{% include "common/standalone/main.j2" %}', start)
@@ -74,7 +74,6 @@ def test_rendered_templates_use_shared_validation_helpers() -> None:
             "ActivationFunctions/relu/relu.c.j2",
             {
                 "name": "relu_smoke",
-                "prefix": "relu",
                 "input_dtype": "int8_t",
                 "output_dtype": "int8_t",
                 "output_size": 4,
@@ -89,7 +88,6 @@ def test_rendered_templates_use_shared_validation_helpers() -> None:
             "ComparisonFunctions/comparison/comparison.c.j2",
             {
                 "name": "comparison_smoke",
-                "prefix": "comparison",
                 "input_dtype": "int8_t",
                 "output_size": 4,
                 "kernel_fn": "arm_equal_s8",
@@ -106,7 +104,6 @@ def test_rendered_templates_use_shared_validation_helpers() -> None:
             "BasicMathFunctions/argmax/argmax.c.j2",
             {
                 "name": "argmax_smoke",
-                "prefix": "argmax",
                 "input_dtype": "int8_t",
                 "output_dtype": "int32_t",
                 "output_size": 4,
@@ -117,7 +114,6 @@ def test_rendered_templates_use_shared_validation_helpers() -> None:
             "QuantizationFunctions/dequantize/dequantize.c.j2",
             {
                 "name": "dequantize_smoke",
-                "prefix": "dequantize",
                 "input_size": 4,
                 "zero_point": 0,
                 "scale": 0.125,
@@ -134,7 +130,6 @@ def test_rendered_templates_use_shared_validation_helpers() -> None:
             "ConcatenationFunctions/split/split.c.j2",
             {
                 "name": "split_smoke",
-                "prefix": "split",
                 "input_dtype": "int8_t",
                 "output_dtype": "int8_t",
                 "kernel_fn": "arm_split_s8",
@@ -175,7 +170,6 @@ def test_basic_math_float_templates_render_preformatted_activation_literals() ->
         "BasicMathFunctions/add/add.c.j2",
         {
             "name": "add_float_default_f32",
-            "prefix": "add_float_default_f32",
             "input_dtype": "float",
             "output_dtype": "float",
             "float_kernel": True,
@@ -190,7 +184,6 @@ def test_basic_math_float_templates_render_preformatted_activation_literals() ->
         "BasicMathFunctions/mul/mul.c.j2",
         {
             "name": "mul_float_default_f32",
-            "prefix": "mul_float_default_f32",
             "input_dtype": "float",
             "output_dtype": "float",
             "float_kernel": True,
@@ -205,7 +198,6 @@ def test_basic_math_float_templates_render_preformatted_activation_literals() ->
         "ActivationFunctions/nn_activation_float/nn_activation_float.c.j2",
         {
             "name": "nn_activation_float_leaky_relu_f32",
-            "prefix": "nn_activation_float_leaky_relu_f32",
             "input_dtype": "float",
             "output_dtype": "float",
             "kernel_fn": "arm_nn_activation_f32",
@@ -229,7 +221,6 @@ def test_pooling_float_header_templates_render_public_float_params() -> None:
         "PoolingFunctions/avg_pool/avg_pool.h.j2",
         {
             "name": "avg_pool_float_default_f32",
-            "prefix": "avg_pool_float_default_f32",
             "input_dtype": "float",
             "output_dtype": "float",
             "pool_params_type": "cmsis_nn_pool_params_f32",
@@ -255,7 +246,6 @@ def test_pooling_float_header_templates_render_public_float_params() -> None:
         "PoolingFunctions/max_pool/max_pool.h.j2",
         {
             "name": "max_pool_float_default_f32",
-            "prefix": "max_pool_float_default_f32",
             "input_dtype": "float",
             "output_dtype": "float",
             "pool_params_type": "cmsis_nn_pool_params_f32",
@@ -292,7 +282,6 @@ def test_complex_float_templates_render_public_f32_signatures() -> None:
         "ConvolutionFunctions/convolve/convolve.h.j2",
         {
             "name": "convolve_float_default_f32",
-            "prefix": "convolve_float_default_f32",
             "input_dims": {"n": 1, "h": 6, "w": 6, "c": 3},
             "filter_dims": {"n": 5, "h": 3, "w": 3, "c": 3},
             "output_dims": {"n": 1, "h": 6, "w": 6, "c": 5},
@@ -316,7 +305,6 @@ def test_complex_float_templates_render_public_f32_signatures() -> None:
         "FullyConnectedFunctions/fully_connected/fully_connected.h.j2",
         {
             "name": "fully_connected_float_default_f32",
-            "prefix": "fully_connected_float_default_f32",
             "input_dims": {"n": 1, "h": 1, "w": 1, "c": 12},
             "filter_dims": {"n": 12, "h": 1, "w": 1, "c": 5},
             "output_dims": {"n": 1, "h": 1, "w": 1, "c": 5},
@@ -345,7 +333,6 @@ def test_complex_float_templates_render_public_f32_signatures() -> None:
         "FullyConnectedFunctions/fully_connected/fully_connected.c.j2",
         {
             "name": "fully_connected_float_default_f32",
-            "prefix": "fully_connected_float_default_f32",
             "input_dims": {"n": 1, "h": 1, "w": 1, "c": 12},
             "filter_dims": {"n": 12, "h": 1, "w": 1, "c": 5},
             "output_dims": {"n": 1, "h": 1, "w": 1, "c": 5},
@@ -374,7 +361,6 @@ def test_complex_float_templates_render_public_f32_signatures() -> None:
         "FullyConnectedFunctions/batch_matmul/batch_matmul.c.j2",
         {
             "name": "batch_matmul_float_default_f32",
-            "prefix": "batch_matmul_float_default_f32",
             "input_lhs_dims": {"n": 1, "h": 1, "w": 4, "c": 3},
             "input_rhs_dims": {"n": 1, "h": 1, "w": 3, "c": 2},
             "output_dims": {"n": 1, "h": 1, "w": 4, "c": 2},
@@ -398,7 +384,6 @@ def test_complex_float_templates_render_public_f32_signatures() -> None:
         "ConvolutionFunctions/transpose_conv/transpose_conv.c.j2",
         {
             "name": "transpose_conv_float_default_f32",
-            "prefix": "transpose_conv_float_default_f32",
             "input_dims": {"n": 1, "h": 4, "w": 4, "c": 2},
             "filter_dims": {"n": 3, "h": 3, "w": 3, "c": 2},
             "output_dims": {"n": 1, "h": 8, "w": 8, "c": 3},
@@ -441,7 +426,6 @@ def test_s16_conv_templates_render_int8_weights_for_public_wrapper_signatures() 
         "ConvolutionFunctions/convolve/convolve.h.j2",
         {
             "name": "convolve_int16xint8xint32_case_04_s16",
-            "prefix": "convolve_int16xint8xint32_case_04_s16",
             "input_dims": {"n": 1, "h": 32, "w": 32, "c": 2},
             "filter_dims": {"n": 2, "h": 2, "w": 2, "c": 2},
             "output_dims": {"n": 1, "h": 30, "w": 30, "c": 2},
@@ -465,7 +449,6 @@ def test_s16_conv_templates_render_int8_weights_for_public_wrapper_signatures() 
         "ConvolutionFunctions/convolve/convolve.c.j2",
         {
             "name": "convolve_int16xint8xint32_case_04_s16",
-            "prefix": "convolve_int16xint8xint32_case_04_s16",
             "input_dims": {"n": 1, "h": 32, "w": 32, "c": 2},
             "filter_dims": {"n": 2, "h": 2, "w": 2, "c": 2},
             "output_dims": {"n": 1, "h": 30, "w": 30, "c": 2},
@@ -489,7 +472,6 @@ def test_s16_conv_templates_render_int8_weights_for_public_wrapper_signatures() 
         "ConvolutionFunctions/depthwise_conv/depthwise_conv.h.j2",
         {
             "name": "depthwise_conv_s16",
-            "prefix": "depthwise_conv_s16",
             "input_dims": {"n": 1, "h": 8, "w": 8, "c": 4},
             "filter_dims": {"n": 1, "h": 3, "w": 3, "c": 4},
             "output_dims": {"n": 1, "h": 6, "w": 6, "c": 4},
@@ -515,7 +497,6 @@ def test_s16_conv_templates_render_int8_weights_for_public_wrapper_signatures() 
         "ConvolutionFunctions/depthwise_conv/depthwise_conv.c.j2",
         {
             "name": "depthwise_conv_s16",
-            "prefix": "depthwise_conv_s16",
             "input_dims": {"n": 1, "h": 8, "w": 8, "c": 4},
             "filter_dims": {"n": 1, "h": 3, "w": 3, "c": 4},
             "output_dims": {"n": 1, "h": 6, "w": 6, "c": 4},
@@ -554,7 +535,6 @@ def test_gather_nd_invalid_status_render_uses_expected_status_helper() -> None:
         "GatherFunctions/gather_nd/gather_nd.c.j2",
         {
             "name": "gather_nd_invalid_smoke",
-            "prefix": "gather_nd",
             "input_dtype": "int8_t",
             "output_dtype": "int8_t",
             "kernel_fn": "arm_gather_nd_s8",
@@ -576,7 +556,6 @@ def test_transpose_invalid_status_render_uses_expected_status_helper() -> None:
         "TransposeFunctions/transpose/transpose.c.j2",
         {
             "name": "transpose_invalid_smoke",
-            "prefix": "transpose",
             "input_dtype": "int8_t",
             "output_dtype": "int8_t",
             "kernel_fn": "arm_transpose_s8",
@@ -598,7 +577,6 @@ def test_transpose_header_float_uses_inline_perm_array() -> None:
         "TransposeFunctions/transpose/transpose.h.j2",
         {
             "name": "transpose_float_smoke",
-            "prefix": "transpose",
             "input_dims": {"n": 1, "h": 2, "w": 3, "c": 4},
             "output_dims": {"n": 1, "h": 3, "w": 2, "c": 4},
             "num_dims": 4,
@@ -622,7 +600,6 @@ def test_transpose_header_int_uses_permutations_pointer() -> None:
         "TransposeFunctions/transpose/transpose.h.j2",
         {
             "name": "transpose_int_smoke",
-            "prefix": "transpose",
             "input_dims": {"n": 1, "h": 2, "w": 3, "c": 4},
             "output_dims": {"n": 1, "h": 3, "w": 2, "c": 4},
             "num_dims": 4,
@@ -646,7 +623,6 @@ def test_rsqrt_invalid_status_render_uses_expected_status_helper() -> None:
         "BasicMathFunctions/rsqrt/rsqrt.c.j2",
         {
             "name": "rsqrt_invalid_smoke",
-            "prefix": "rsqrt",
             "call_style": "per_op",
             "input_dtype": "int16_t",
             "output_dtype": "int16_t",
@@ -674,7 +650,6 @@ def test_broadcast_to_invalid_status_render_uses_expected_status_helper() -> Non
         "BroadcastFunctions/broadcast_to/broadcast_to.c.j2",
         {
             "name": "broadcast_invalid_smoke",
-            "prefix": "broadcast",
             "c_type": "int8_t",
             "kernel_fn": "arm_broadcast_to_s8",
             "output_size": 4,
@@ -696,7 +671,6 @@ def test_dynamic_update_slice_invalid_status_render_uses_expected_status_helper(
         "DynamicUpdateSliceFunctions/dynamic_update_slice/dynamic_update_slice.c.j2",
         {
             "name": "dynamic_update_slice_invalid_smoke",
-            "prefix": "dynamic_update_slice",
             "c_type": "int8_t",
             "kernel_fn": "arm_dynamic_update_slice_s8",
             "operand_size": 20,
@@ -788,7 +762,6 @@ def test_quantize_and_dequantize_render_only_requested_validation_helpers() -> N
         "QuantizationFunctions/quantize/quantize.c.j2",
         {
             "name": "quantize_smoke",
-            "prefix": "quantize",
             "input_size": 4,
             "zero_point": 0,
             "scale": 0.125,
@@ -808,7 +781,6 @@ def test_quantize_and_dequantize_render_only_requested_validation_helpers() -> N
         "QuantizationFunctions/dequantize/dequantize.c.j2",
         {
             "name": "dequantize_smoke",
-            "prefix": "dequantize",
             "input_size": 4,
             "zero_point": 0,
             "scale": 0.125,
@@ -825,43 +797,46 @@ def test_quantize_and_dequantize_render_only_requested_validation_helpers() -> N
         },
     )
 
-    assert "#define HELIA_VALIDATE_TOLERANT_INTS" in quantize
-    assert "#define HELIA_VALIDATE_FLOATS" not in quantize
-    assert "#define HELIA_VALIDATE_EXACT_INTS" not in quantize
-    assert "#define HELIA_VALIDATE_BOOLEANS" not in quantize
+    # The HELIA_VALIDATE_* macro definitions themselves live once in the shared
+    # helia_test_runtime header (see test_shared_runtime_header_defines_all_validators
+    # below), not in per-template rendered text. Templates only need to select the
+    # correct dispatch mode for their requested validation_helpers.
     assert "TOLERANT_INT" in quantize
+    assert "EXACT_INT" not in quantize
 
-    assert "#define HELIA_VALIDATE_FLOATS" in dequantize
-    assert "#define HELIA_VALIDATE_TOLERANT_INTS" not in dequantize
-    assert "#define HELIA_VALIDATE_EXACT_INTS" not in dequantize
-    assert "#define HELIA_VALIDATE_BOOLEANS" not in dequantize
     assert "FLOAT" in dequantize
+    assert "TOLERANT_INT" not in dequantize
+    assert "EXACT_INT" not in dequantize
+
+
+def test_shared_runtime_header_defines_all_validators() -> None:
+    header = (
+        _repo_root() / "src" / "test_runtime" / "helia_test_runtime.h"
+    ).read_text()
+
+    for macro in (
+        "HELIA_VALIDATE_EXACT_INTS",
+        "HELIA_VALIDATE_TOLERANT_INTS",
+        "HELIA_VALIDATE_FLOATS",
+        "HELIA_VALIDATE_BOOLEANS",
+        "HELIA_VALIDATE_OUTPUTS_EXACT_INT",
+        "HELIA_VALIDATE_OUTPUTS_TOLERANT_INT",
+        "HELIA_VALIDATE_OUTPUTS_FLOAT",
+        "HELIA_VALIDATE_OUTPUTS_BOOL",
+        "HELIA_VALIDATE_OUTPUTS_NONE",
+    ):
+        assert f"#define {macro}(" in header, macro
 
 
 def test_rendered_float_validator_uses_additive_tolerance() -> None:
-    rendered = _render(
-        "QuantizationFunctions/dequantize/dequantize.c.j2",
-        {
-            "name": "dequantize_tolerance_smoke",
-            "prefix": "dequantize",
-            "input_size": 4,
-            "zero_point": 0,
-            "scale": 0.125,
-            "input_data_array": "    0",
-            "expected_output_array": "    0.000000f",
-            "input_dtype": "int8_t",
-            "output_dtype": "float",
-            "kernel_fn": "arm_dequantize_s8_f32",
-            "has_activation": False,
-            "activation_type": "NONE",
-            "comparison_atol": 1.0e-5,
-            "comparison_rtol": 1.0e-5,
-            "validation_helpers": ["float"],
-        },
-    )
+    # The float-tolerance formula is defined once in the shared runtime source
+    # (compiled into helia_test_runtime), not re-emitted per rendered template.
+    source = (
+        _repo_root() / "src" / "test_runtime" / "helia_test_runtime.c"
+    ).read_text()
 
-    assert "return (atol + (rtol * fabs(expected)));" in rendered
-    assert "helia_test_max_double" not in rendered
+    assert "return (atol + (rtol * fabs(expected)));" in source
+    assert "helia_test_max_double" not in source
 
 
 def test_build_validation_context_derives_dtype_specific_float_defaults() -> None:
@@ -910,4 +885,4 @@ def test_top_level_cmake_no_longer_uses_unity() -> None:
     assert "unity_fetch" not in text
     assert "ThrowTheSwitch/Unity" not in text
     assert "FetchContent_Declare(unity" not in text
-    assert "target_link_libraries(${TGT_NAME} PRIVATE cmsis-nn retarget cmsis_startup)" in text
+    assert "target_link_libraries(${TGT_NAME} PRIVATE cmsis-nn retarget cmsis_startup helia_test_runtime)" in text

--- a/helia_core_tester/tests/test_validation_mode_dtype_wins.py
+++ b/helia_core_tester/tests/test_validation_mode_dtype_wins.py
@@ -1,0 +1,103 @@
+"""Regression lock for issue #54: float outputs must get float validation.
+
+Before the fix, ``infer_validation_mode`` consulted template-path allowlists
+before the output dtype, so float descriptors routed through shared int
+templates (convolve, pooling, softmax, lstm, ...) emitted an INTEGER
+comparison: ``(long long)`` truncation made every output with ``|v| < 1``
+match unconditionally. 209 of 373 float cases performed no float comparison
+at all; a 5% error in every Convolve output and a swapped LSTM gate pair both
+passed 100% of their suites.
+
+These tests pin the contract: output dtype wins over the allowlists, and a
+float-dtype context can never resolve (or be explicitly coerced) to an
+integer validation mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from helia_core_tester.generation.utils.template_context import TemplateContextBuilder
+
+
+_INT_ALLOWLISTED_TEMPLATES = sorted(
+    TemplateContextBuilder._EXACT_INT_VALIDATION_TEMPLATES
+    | TemplateContextBuilder._TOLERANT_INT_VALIDATION_TEMPLATES
+)
+
+_FLOAT_OUTPUT_DTYPES = ("float32_t", "float16_t", "float")
+
+
+@pytest.mark.parametrize("template_path", _INT_ALLOWLISTED_TEMPLATES)
+@pytest.mark.parametrize("output_dtype", _FLOAT_OUTPUT_DTYPES)
+def test_float_dtype_wins_over_int_template_allowlists(template_path, output_dtype):
+    """Every int-allowlisted template must yield FLOAT mode for float outputs."""
+    mode = TemplateContextBuilder.infer_validation_mode(
+        template_path, {"output_dtype": output_dtype}
+    )
+    assert mode == "float", (
+        f"{template_path} resolved '{mode}' for output_dtype={output_dtype}; "
+        "float outputs must use the float validator (issue #54)"
+    )
+
+
+@pytest.mark.parametrize("template_path", _INT_ALLOWLISTED_TEMPLATES)
+def test_int_dtype_still_uses_template_allowlists(template_path):
+    """Int descriptors keep their historical int comparison modes."""
+    expected = (
+        "exact_int"
+        if template_path in TemplateContextBuilder._EXACT_INT_VALIDATION_TEMPLATES
+        else "tolerant_int"
+    )
+    mode = TemplateContextBuilder.infer_validation_mode(
+        template_path, {"output_dtype": "int8_t"}
+    )
+    assert mode == expected
+
+
+@pytest.mark.parametrize("coerced_mode", ("exact_int", "tolerant_int"))
+def test_explicit_int_coercion_of_float_output_is_rejected(coerced_mode):
+    """An explicit validation_mode override cannot force int compare on floats."""
+    with pytest.raises(ValueError, match="coercion"):
+        TemplateContextBuilder.build_validation_context(
+            "ConvolutionFunctions/convolve/convolve.c.j2",
+            {"output_dtype": "float32_t", "validation_mode": coerced_mode},
+        )
+
+
+@pytest.mark.parametrize(
+    "template_path",
+    (
+        "LSTMFunctions/lstm_unidirectional/lstm_unidirectional.c.j2",
+        "SVDFunctions/svdf/svdf.c.j2",
+    ),
+)
+def test_data_dtype_fallback_covers_generators_without_output_dtype(template_path):
+    """LSTM/SVDF historically set only data_dtype; the resolver must fall back
+    to it rather than silently dropping to the int allowlists (issue #54)."""
+    mode = TemplateContextBuilder.infer_validation_mode(
+        template_path, {"data_dtype": "float16_t"}
+    )
+    assert mode == "float"
+
+
+def test_output_dtype_beats_data_dtype_when_both_present():
+    """Quantize-style ops (float data in, int out) must keep int validation."""
+    mode = TemplateContextBuilder.infer_validation_mode(
+        "QuantizationFunctions/quantize/quantize.c.j2",
+        {"data_dtype": "float", "output_dtype": "int8_t"},
+    )
+    assert mode == "tolerant_int"
+
+
+def test_build_validation_context_emits_float_for_float_output():
+    """End-to-end: a float context through an int-allowlisted template renders
+    FLOAT mode, float helpers, and the dtype-default tolerances."""
+    resolved = TemplateContextBuilder.build_validation_context(
+        "ConvolutionFunctions/convolve/convolve.c.j2",
+        {"output_dtype": "float32_t"},
+    )
+    assert resolved["validation_mode"] == "float"
+    assert resolved["validation_mode_token"] == "FLOAT"
+    assert "float" in resolved["validation_helpers"]
+    assert resolved["validation_atol"] > 0.0

--- a/helia_core_tester/tests/test_validation_mode_dtype_wins.py
+++ b/helia_core_tester/tests/test_validation_mode_dtype_wins.py
@@ -55,7 +55,7 @@ def test_int_dtype_still_uses_template_allowlists(template_path):
     assert mode == expected
 
 
-@pytest.mark.parametrize("coerced_mode", ("exact_int", "tolerant_int"))
+@pytest.mark.parametrize("coerced_mode", ("exact_int", "tolerant_int", "bool", "none"))
 def test_explicit_int_coercion_of_float_output_is_rejected(coerced_mode):
     """An explicit validation_mode override cannot force int compare on floats."""
     with pytest.raises(ValueError, match="coercion"):

--- a/src/test_runtime/helia_test_runtime.c
+++ b/src/test_runtime/helia_test_runtime.c
@@ -1,0 +1,74 @@
+#include "test_runtime/helia_test_runtime.h"
+
+#include <stdio.h>
+
+#ifdef USING_FVP_CORSTONE_300
+extern void uart_init(void);
+#endif
+
+void helia_test_platform_init(void)
+{
+#ifdef USING_FVP_CORSTONE_300
+    uart_init();
+#endif
+    setvbuf(stdout, NULL, _IONBF, 0);
+}
+
+static void helia_test_signal_eot(void)
+{
+    // 0x04 (EOT) triggers FVP shutdown when:
+    //   -C mps3_board.uart0.shutdown_on_eot=1
+    putchar(4);
+    fflush(stdout);
+}
+
+void helia_test_finish(int32_t failures)
+{
+    (void)failures;
+    helia_test_signal_eot();
+    while (1) { }
+}
+
+void HardFault_Handler(void)
+{
+    printf("HardFault\r\n");
+    helia_test_signal_eot();
+    while (1) { }
+}
+
+void helia_test_print_failure_count(int failures)
+{
+    printf("%d Failures\r\n", failures);
+}
+
+int helia_test_status_failure(const char *label, int status)
+{
+    printf("%s failed with status %d\r\n", label, status);
+    helia_test_print_failure_count(1);
+    return 1;
+}
+
+int helia_test_expected_status_failure(const char *label, int status, int expected_status)
+{
+    printf("%s failed with status %d (expected %d)\r\n", label, status, expected_status);
+    helia_test_print_failure_count(1);
+    return 1;
+}
+
+int helia_test_scalar_int_mismatch(const char *label, const char *subject, int expected, int actual)
+{
+    printf("%s %s mismatch: expected %d got %d\r\n", label, subject, expected, actual);
+    helia_test_print_failure_count(1);
+    return 1;
+}
+
+int helia_test_finish_validation(int failures)
+{
+    helia_test_print_failure_count(failures);
+    return failures;
+}
+
+double helia_test_float_tolerance(double expected, double atol, double rtol)
+{
+    return (atol + (rtol * fabs(expected)));
+}

--- a/src/test_runtime/helia_test_runtime.h
+++ b/src/test_runtime/helia_test_runtime.h
@@ -1,41 +1,55 @@
-#ifndef HELIA_CORE_TEMPLATE_VALIDATE_H
-#define HELIA_CORE_TEMPLATE_VALIDATE_H
-{% set validation_helpers = validation_helpers | default([]) %}
+/*
+ * Shared standalone-firmware runtime for generated helia-core-tester tests.
+ *
+ * Every generated test .c file is its own standalone firmware image (its own
+ * main()/HardFault_Handler/etc.), but the runtime and validation logic itself
+ * is identical across all ~2,000+ generated files. Rather than re-emitting
+ * this logic via Jinja into every generated file, it is compiled exactly once
+ * into the `helia_test_runtime` static library and linked into every test
+ * executable (see CMakeLists.txt). Generated files only need:
+ *
+ *   #include "test_runtime/helia_test_runtime.h"
+ *
+ * Validation macros (HELIA_VALIDATE_*) intentionally remain macros: they
+ * must expand at the call site so the compiler can see the concrete element
+ * type of the caller's arrays (for the compile-time float/int guard and for
+ * correct promotion in the per-type loops below). Everything that does NOT
+ * need call-site type information (platform init, fault handling, failure
+ * reporting) is a plain compiled function instead.
+ */
+#ifndef HELIA_TEST_RUNTIME_H
+#define HELIA_TEST_RUNTIME_H
 
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
 
-static inline void helia_test_print_failure_count(int failures)
-{
-    printf("%d Failures\r\n", failures);
-}
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-static inline int helia_test_status_failure(const char *label, int status)
-{
-    printf("%s failed with status %d\r\n", label, status);
-    helia_test_print_failure_count(1);
-    return 1;
-}
+/* ---------------------------------------------------------------------- */
+/* Platform / lifecycle (defined once in helia_test_runtime.c)            */
+/* ---------------------------------------------------------------------- */
 
-static inline int helia_test_expected_status_failure(const char *label, int status, int expected_status)
-{
-    printf("%s failed with status %d (expected %d)\r\n", label, status, expected_status);
-    helia_test_print_failure_count(1);
-    return 1;
-}
+void helia_test_platform_init(void);
+void helia_test_finish(int32_t failures);
 
-static inline int helia_test_scalar_int_mismatch(const char *label, const char *subject, int expected, int actual)
-{
-    printf("%s %s mismatch: expected %d got %d\r\n", label, subject, expected, actual);
-    helia_test_print_failure_count(1);
-    return 1;
-}
+/* ---------------------------------------------------------------------- */
+/* Failure reporting (defined once in helia_test_runtime.c)               */
+/* ---------------------------------------------------------------------- */
 
-static inline int helia_test_finish_validation(int failures)
-{
-    helia_test_print_failure_count(failures);
-    return failures;
+void helia_test_print_failure_count(int failures);
+int helia_test_status_failure(const char *label, int status);
+int helia_test_expected_status_failure(const char *label, int status, int expected_status);
+int helia_test_scalar_int_mismatch(const char *label, const char *subject, int expected, int actual);
+int helia_test_finish_validation(int failures);
+double helia_test_float_tolerance(double expected, double atol, double rtol);
+
+#ifdef __cplusplus
 }
+#endif
 
 #define HELIA_VALIDATE_EXPECTED_STATUS(label, status, expected_status) \
     do { \
@@ -64,7 +78,6 @@ static inline int helia_test_finish_validation(int failures)
 #define HELIA_VALIDATE_RETURN_FAILURES(failures) \
     return helia_test_finish_validation((failures))
 
-{% if "exact_int" in validation_helpers or "tolerant_int" in validation_helpers %}
 /*
  * Compile-time guard (issue #54): the integer validators cast elements to
  * long long, which silently truncates float outputs (|v| < 1 becomes 0 on
@@ -89,16 +102,7 @@ static inline int helia_test_finish_validation(int failures)
     _Static_assert(!HELIA_ELEM_IS_FLOAT((arr)[0]), \
                    "integer validator applied to float outputs: validation-mode coercion " \
                    "(helia-core-tester issue #54); float outputs need the FLOAT validator")
-{% endif %}
 
-{% if "float" in validation_helpers %}
-static inline double helia_test_float_tolerance(double expected, double atol, double rtol)
-{
-    return (atol + (rtol * fabs(expected)));
-}
-{% endif %}
-
-{% if "exact_int" in validation_helpers %}
 #define HELIA_VALIDATE_EXACT_INTS(actual, expected, size, max_reports, failures) \
     do { \
         HELIA_ASSERT_INT_VALIDATOR_INPUT(actual); \
@@ -114,9 +118,7 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
             } \
         } \
     } while (0)
-{% endif %}
 
-{% if "tolerant_int" in validation_helpers %}
 #define HELIA_VALIDATE_TOLERANT_INTS(actual, expected, size, tolerance, max_reports, failures) \
     do { \
         HELIA_ASSERT_INT_VALIDATOR_INPUT(actual); \
@@ -142,9 +144,7 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
             } \
         } \
     } while (0)
-{% endif %}
 
-{% if "float" in validation_helpers %}
 #define HELIA_VALIDATE_FLOATS(actual, expected, size, atol, rtol, max_reports, failures) \
     do { \
         for (int helia_i = 0; helia_i < (size); ++helia_i) { \
@@ -171,9 +171,7 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
             } \
         } \
     } while (0)
-{% endif %}
 
-{% if "bool" in validation_helpers %}
 #define HELIA_VALIDATE_BOOLEANS(actual, expected, size, max_reports, failures) \
     do { \
         for (int helia_i = 0; helia_i < (size); ++helia_i) { \
@@ -187,7 +185,6 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
             } \
         } \
     } while (0)
-{% endif %}
 
 #define HELIA_VALIDATE_OUTPUTS_EXACT_INT(actual, expected, size, tolerance, atol, rtol, max_reports, failures) \
     HELIA_VALIDATE_EXACT_INTS((actual), (expected), (size), (max_reports), (failures))
@@ -216,4 +213,4 @@ static inline double helia_test_float_tolerance(double expected, double atol, do
 #define HELIA_VALIDATE_OUTPUTS(mode, actual, expected, size, tolerance, atol, rtol, max_reports, failures) \
     HELIA_VALIDATE_OUTPUTS_##mode((actual), (expected), (size), (tolerance), (atol), (rtol), (max_reports), (failures))
 
-#endif
+#endif /* HELIA_TEST_RUNTIME_H */


### PR DESCRIPTION
Fixes #54 — **56% of float test cases never performed a float comparison** (float outputs compared via `(long long)` cast, so every |v| < 1 matched unconditionally). A 5% error in every Convolve output and a swapped LSTM gate pair both passed 100% of their suites.

## Also in this PR: float bias paths are now actually tested

All 46 Convolve float cases shipped all-zero biases and all 10 FullyConnected float cases passed `biases = NULL`. Root cause: Keras' default zero `bias_initializer` gets **constant-folded away by the TFLite converter** for float graphs, so extraction legitimately found no bias. Fixed with a deterministic nonzero initializer (`use_bias: false` cases untouched), plus a second bug this exposed: for **dilated** convs TFLite hoists the bias-add into a separate `ADD` after `BatchToSpaceND`, leaving a zero placeholder on the CONV — extraction now follows the hoist (float-scoped; S8 output verified byte-identical, which has the same latent pattern with different semantics — left for a follow-up issue).

**Verified**: baseline 58/58 pass on QEMU with real biases (no kernel bias bugs); a bias-dropped mutant kernel fails **exactly** the 15 biased cases reachable through the mutated entry points and none of the no-bias/other-path cases — previously this mutation class was undetectable (0/46). Also drops the unjustified `tanh_f16` tolerance override per #53 (measured benefit of the 15× rtol: zero).

## The fix — three layers, so this class of bug cannot recur silently

1. **Dtype-first mode resolution** (`d56eae7`): output dtype (falling back to `data_dtype`) wins over the template-path allowlists. Int descriptors unaffected. LSTM/SVDF generators — which only set `data_dtype`, the reason they were still coerced after the naive fix — now set `output_dtype` explicitly.
2. **Generation-time invariant**: `build_validation_context` raises if a float output resolves (or is explicitly coerced) to an int mode.
3. **Compile-time C guard**: the int validators `_Static_assert` (via `_Generic`, incl. `__fp16`) that their element type is not float — a future generator regression **fails the build** with a pointer to #54 instead of passing forever. Verified on cortex-m55 and cortex-m4: int arrays compile, float32/`__fp16` misuse blocked.

Plus a **200-test pytest regression lock** (every int-allowlisted template × float dtype, int non-regression, `data_dtype` fallback, quantize float-in/int-out ordering, explicit-coercion rejection).

## Third-round review correction (load-bearing)

The #53 audit's conclusion that the `tanh_f16` tolerance overrides had "zero measured benefit" was **wrong for the scalar-fallback CI leg** — it was measured on MVE codegen only. The fallback leg (`-O0` + `AUTOVECTORIZE`) has a 1.03e-2 tanh f16 floor, >6× the default. The overrides are restored at rtol 0.02 with the fallback rationale documented in the descriptor. Also correcting stale counts: the pytest lock is 200 tests; reverting the fix fails 151 of them. Note: early commit messages on this branch contain claims superseded by later review-driven commits (tolerances, bias scoping) — the PR body and final tree are authoritative.

## Verified

- Full float suite regenerated: **360 cases emit FLOAT**; the only int-mode survivors are Quantize (genuinely int8/int16 outputs — correct).
- Full 375-case run on QEMU mps3-an547 against ns-cmsis-nn main: **365 pass / 10 fail** on first-ever real comparisons.
- Pytest: identical 12 pre-existing failures as pristine main, zero new.

## Fallout triage (the 10)

- **6 = a real shipped kernel bug**: transpose-conv float output shifted +1 in H/W for odd-remainder SAME configs, shipped since v7.28.0, masked by this very bug — fixed in AmbiqAI/ns-cmsis-nn#253 (root-caused with independent float64 reference; goldens confirmed exact).
- **4 = measured tolerance floors** (`1889f90`): LSTM f16 ×3 and conv patch-GEMM f16 — f32 twins all pass, so precision floors, not defects. Tolerances set from measured floors with documented rationale (LSTM f16 → 0.01 matching the GRU-f16 family from #52; gate-swap mutation re-verified failing 5/5 at the new tolerance). Re-verified post-disconnect on QEMU: all 4 pass, controls green.

## Merge order

This PR → ns-cmsis-nn#253 (already green) → submodule bump in ns-cmsis-nn (do **not** bump before #253 merges: the newly-real transpose-conv comparisons would correctly fail against the unfixed kernel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


