### PR TITLE
fix(generation): include rolling-buffer size in transpose-conv scratch bound

### DIFF
--- a/helia_core_tester/generation/utils/template_context.py
+++ b/helia_core_tester/generation/utils/template_context.py
@@ -907,7 +907,19 @@ class TemplateContextBuilder:
 
         reverse_conv_possible = (stride_w <= 2) and (stride_h <= 2)
         reverse_conv_efficient = (input_c > reverse_tcol_threshold)
-        
+
+        # Rolling-buffer sizing (ns-cmsis-nn issue #261 / PR #262): this is the
+        # formula arm_transpose_conv_s8_get_buffer_size() (and the _mve variant)
+        # uses directly, and also the lower bound it enforces even when the
+        # reverse-conv route is taken (other direct callers of
+        # arm_transpose_conv_s8 still need the rolling-buffer sizing). Computed
+        # once here so the reverse and non-reverse branches below can never
+        # diverge on this formula.
+        buf_x = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_w)) * output_c
+        buf_x_mve = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_h)) * output_c
+        buf_y = max(filter_h, stride_h)
+        rolling_ctx_size = max(buf_x, buf_x_mve) * buf_y * 4  # int32 scratch
+
         if output_dtype == 'S16':
             # S16 buffer size (conservative estimate)
             buffer_size_mve = 4 * 8 * filter_w * filter_h * 2  # sizeof(int16_t) = 2
@@ -933,17 +945,10 @@ class TemplateContextBuilder:
                 # now returns MAX(reverse-conv size, rolling-buffer size), because other
                 # direct callers of arm_transpose_conv_s8 still need the rolling-buffer
                 # sizing. Mirror that here so this harness bound stays an upper bound.
-                buf_x = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_w)) * output_c
-                buf_x_mve = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_h)) * output_c
-                buf_y = max(filter_h, stride_h)
-                rolling_ctx_size = max(buf_x, buf_x_mve) * buf_y * 4  # int32 scratch
                 ctx_size = max(reverse_conv_ctx_size, rolling_ctx_size)
                 output_ctx_size = input_c * filter_w * filter_h * filter_dims['n']
             else:
-                buf_x = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_w)) * output_c
-                buf_x_mve = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_h)) * output_c
-                buf_y = max(filter_h, stride_h)
-                ctx_size = max(buf_x, buf_x_mve) * buf_y * 4  # int32 scratch
+                ctx_size = rolling_ctx_size
                 output_ctx_size = 0
         
         # Return maximum of ctx and output_ctx

--- a/helia_core_tester/generation/utils/template_context.py
+++ b/helia_core_tester/generation/utils/template_context.py
@@ -922,12 +922,22 @@ class TemplateContextBuilder:
                     'w': input_dims['w'] * stride_w,
                     'c': input_c,
                 }
-                ctx_size = TemplateContextBuilder.calculate_buffer_size_max(
+                reverse_conv_ctx_size = TemplateContextBuilder.calculate_buffer_size_max(
                     reverse_conv_input_dims,
                     filter_dims,
                     output_dims,
                     output_dtype='S8',
                 )
+                # ns-cmsis-nn issue #261 / PR #262: even when the reverse-conv route is
+                # taken, arm_transpose_conv_s8_get_buffer_size() (and the _mve variant)
+                # now returns MAX(reverse-conv size, rolling-buffer size), because other
+                # direct callers of arm_transpose_conv_s8 still need the rolling-buffer
+                # sizing. Mirror that here so this harness bound stays an upper bound.
+                buf_x = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_w)) * output_c
+                buf_x_mve = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_h)) * output_c
+                buf_y = max(filter_h, stride_h)
+                rolling_ctx_size = max(buf_x, buf_x_mve) * buf_y * 4  # int32 scratch
+                ctx_size = max(reverse_conv_ctx_size, rolling_ctx_size)
                 output_ctx_size = input_c * filter_w * filter_h * filter_dims['n']
             else:
                 buf_x = ((input_dims['w'] - 1) * stride_w + max(filter_w, stride_w)) * output_c

--- a/helia_core_tester/tests/test_lstm_and_transpose_conv_regressions.py
+++ b/helia_core_tester/tests/test_lstm_and_transpose_conv_regressions.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
+from helia_core_tester.generation.io.descriptors import load_descriptor
 from helia_core_tester.generation.utils import lstm_data
 from helia_core_tester.generation.utils.template_context import TemplateContextBuilder
 
@@ -19,6 +21,124 @@ def test_transpose_conv_s8_non_reverse_buffer_covers_mve_stride_h_width_term() -
     )
 
     assert buffer_size == 1920
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_transpose_conv_descriptor(name: str) -> dict:
+    desc_path = _repo_root() / "assets" / "descriptors" / "ConvolutionFunctions" / "transpose_conv.yaml"
+    for desc in load_descriptor(str(desc_path)):
+        if desc.get("name") == name:
+            return desc
+    raise AssertionError(f"descriptor {name!r} not found in {desc_path}")
+
+
+def test_transpose_conv_s8_reverse_buffer_covers_rolling_buffer_after_ns_cmsis_nn_262() -> None:
+    """Regression for ns-cmsis-nn#261 / PR#262.
+
+    arm_transpose_conv_s8_get_buffer_size (and the _mve variant) now returns
+    MAX(reverse-conv size, rolling-buffer size) whenever the reverse-conv route
+    is taken (stride_w<=2 && stride_h<=2 && input_c>16), because other direct
+    callers of arm_transpose_conv_s8 still need the rolling-buffer sizing. The
+    tester's static scratch buffer must stay an upper bound on that new max.
+
+    Dims below are read from the transpose_conv_reverse_valid_kernel1x1_stride2x2_no_bias_s8
+    descriptor (input_c=17, kernel 1x1, stride 2x2, VALID) and reflect the dims
+    actually plugged into the harness at generation time: filter/output channel
+    count is 17 because Keras' Conv2DTranspose infers the kernel's input-channel
+    dimension from the real input tensor (17), not from the descriptor's nominal
+    filter_shape InCh (5) -- confirmed by inspecting a generated harness for this
+    descriptor.
+    """
+    desc = _load_transpose_conv_descriptor(
+        "transpose_conv_reverse_valid_kernel1x1_stride2x2_no_bias_s8"
+    )
+    strides = desc["strides"]
+    stride_h, stride_w = int(strides[0]), int(strides[1])
+    in_n, in_h, in_w, in_c = (int(v) for v in desc["input_shape"])
+    kh, kw, out_ch, _in_ch = (int(v) for v in desc["filter_shape"])
+
+    assert desc["padding"].upper() == "VALID"
+    assert (in_c, kh, kw, stride_h, stride_w) == (17, 1, 1, 2, 2)
+
+    input_dims = {"n": in_n, "h": in_h, "w": in_w, "c": in_c}
+    # Real output channel count generated for this descriptor (see docstring).
+    filter_dims = {"n": out_ch, "h": kh, "w": kw, "c": in_c}
+    output_dims = {"n": in_n, "h": 2, "w": 4, "c": in_c}
+
+    buffer_size = TemplateContextBuilder.calculate_transpose_conv_buffer_size_max(
+        input_dims=input_dims,
+        filter_dims=filter_dims,
+        output_dims=output_dims,
+        output_dtype="S8",
+        stride_h=stride_h,
+        stride_w=stride_w,
+    )
+
+    # Old reverse-only sizing yields 128 (ctx) vs. an output_ctx of 289, so the
+    # old function returns 289 for this shape -- comfortably short of the
+    # rolling-buffer requirement of 544 introduced by PR#262.
+    assert buffer_size >= 160
+    assert buffer_size == 544
+
+
+@pytest.mark.parametrize(
+    ("input_dims", "filter_dims", "output_dims", "stride_h", "stride_w"),
+    (
+        (
+            {"n": 1, "h": 1, "w": 2, "c": 17},
+            {"n": 17, "h": 1, "w": 1, "c": 17},
+            {"n": 1, "h": 2, "w": 4, "c": 17},
+            2,
+            2,
+        ),
+        (
+            {"n": 1, "h": 2, "w": 2, "c": 20},
+            {"n": 20, "h": 1, "w": 1, "c": 20},
+            {"n": 1, "h": 4, "w": 4, "c": 20},
+            2,
+            2,
+        ),
+        (
+            {"n": 1, "h": 1, "w": 4, "c": 24},
+            {"n": 24, "h": 1, "w": 1, "c": 24},
+            {"n": 1, "h": 2, "w": 8, "c": 24},
+            2,
+            1,
+        ),
+    ),
+)
+def test_transpose_conv_s8_reverse_buffer_covers_rolling_formula(
+    input_dims: dict,
+    filter_dims: dict,
+    output_dims: dict,
+    stride_h: int,
+    stride_w: int,
+) -> None:
+    """calculate_transpose_conv_buffer_size_max must bound the rolling-buffer
+    formula whenever the reverse-conv route is possible+efficient (mirrors
+    ns-cmsis-nn PR#262's MAX(reverse, rolling) change)."""
+    output_c = output_dims["c"]
+    filter_w = filter_dims["w"]
+    filter_h = filter_dims["h"]
+
+    buf_x = ((input_dims["w"] - 1) * stride_w + max(filter_w, stride_w)) * output_c
+    buf_x_mve = ((input_dims["w"] - 1) * stride_w + max(filter_w, stride_h)) * output_c
+    buf_y = max(filter_h, stride_h)
+    expected_rolling = max(buf_x, buf_x_mve) * buf_y * 4
+
+    buffer_size = TemplateContextBuilder.calculate_transpose_conv_buffer_size_max(
+        input_dims=input_dims,
+        filter_dims=filter_dims,
+        output_dims=output_dims,
+        output_dtype="S8",
+        stride_h=stride_h,
+        stride_w=stride_w,
+    )
+
+    assert buffer_size >= expected_rolling
 
 
 class _FakeWeight:


### PR DESCRIPTION
Companion to AmbiqAI/ns-cmsis-nn#262 (fixes for issue ns-cmsis-nn#261) — **must be released and the ns-cmsis-nn submodule pin bumped before or together with that PR**, or its CI goes red.

## Why

ns-cmsis-nn#262 changes `arm_transpose_conv_s8_get_buffer_size[_mve]()` to return `MAX(reverse-conv size, rolling-buffer size)` when the reverse-conv route is eligible (stride ≤ 2, in_ch > 16), because the documented contract covers direct `arm_transpose_conv_s8()` callers too and the old reverse-only size under-allocates for them (ASan-confirmed heap overflow).

The generated harness declares a static scratch array bounded by `calculate_transpose_conv_buffer_size_max()` and hard-fails at runtime if the real `get_buffer_size()` exceeds it. That Python function mirrored the old reverse-only C logic, so after ns-cmsis-nn#262 the descriptor `transpose_conv_reverse_valid_kernel1x1_stride2x2_no_bias_s8` fails: emitted bound 289, kernel now requires 544.

## Change

- `calculate_transpose_conv_buffer_size_max` (S8 reverse-conv branch): `ctx_size = max(reverse_conv_ctx_size, rolling_ctx_size)`, with the rolling term computed by the identical formula the non-reverse branch already uses. Diff is scoped to this one function — no overlap with #55's changes in the same file.
- Regression tests: the real descriptor's bound must now be 544 (was 289, verified by regenerating the actual harness end-to-end), plus parametrized shapes asserting bound ≥ rolling formula across the reverse-eligible region. All 4 new tests fail on the old formula (stash-verified) and pass on the fix.

## Verification

- Regenerated harness for the affected descriptor: `BUFFER_SIZE_MAX` 289 → 544 in the emitted C.
- Full pytest: 209 passed; the 12 pre-existing failures are name-identical to a pristine `main` baseline clone — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
