### PR TITLE
test(transpose_conv): add pad%stride!=0 s8 coverage for the #260 bug class

### DIFF
--- a/assets/descriptors/ConvolutionFunctions/transpose_conv.yaml
+++ b/assets/descriptors/ConvolutionFunctions/transpose_conv.yaml
@@ -227,3 +227,85 @@ strides:
 - 1
 padding: VALID
 use_bias: false
+---
+# helia-core-tester#58: pad_h % stride_h != 0 (row remainder), pad_w % stride_w == 0.
+# SAME padding: pad_total = kernel - stride (independent of spatial extent), pad = pad_total // 2.
+# kernel_h=4, stride_h=2 -> pad_total_h=2, pad_h=1, 1 % 2 = 1 (!= 0).
+# kernel_w=6, stride_w=2 -> pad_total_w=4, pad_w=2, 2 % 2 = 0.
+# This is the exact configuration class that hid the s8 row-misalignment bug (ns-cmsis-nn#260)
+# until the fix landed on ns-cmsis-nn main.
+operator: TransposeConv
+name: transpose_conv_same_kernel4x6_stride2x2_bias_padrem_h_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape:
+- 1
+- 5
+- 5
+- 8
+filter_shape:
+- 4
+- 6
+- 8
+- 4
+strides:
+- 2
+- 2
+padding: SAME
+use_bias: true
+---
+# helia-core-tester#58: pad_w % stride_w != 0 (column remainder), pad_h % stride_h == 0.
+# kernel_h=6, stride_h=2 -> pad_total_h=4, pad_h=2, 2 % 2 = 0.
+# kernel_w=4, stride_w=2 -> pad_total_w=2, pad_w=1, 1 % 2 = 1 (!= 0).
+operator: TransposeConv
+name: transpose_conv_same_kernel6x4_stride2x2_no_bias_padrem_w_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape:
+- 1
+- 5
+- 5
+- 8
+filter_shape:
+- 6
+- 4
+- 8
+- 4
+strides:
+- 2
+- 2
+padding: SAME
+use_bias: false
+---
+# helia-core-tester#58: both pad_h % stride_h != 0 AND pad_w % stride_w != 0.
+# Mirrors upstream ARM-software/CMSIS-NN#230's minimal repro shape (4x4x8 input, 4x4
+# kernel, stride 2 -> SAME gives pad 1 on both axes): kernel=4, stride=2 ->
+# pad_total=2, pad=1, 1 % 2 = 1 (!= 0) on both H and W.
+operator: TransposeConv
+name: transpose_conv_same_kernel4x4_stride2x2_bias_padrem_hw_s8
+activation_dtype: S8
+weight_dtype: S8
+activation: NONE
+hint:
+  call_style: per_tensor
+input_shape:
+- 1
+- 4
+- 4
+- 8
+filter_shape:
+- 4
+- 4
+- 8
+- 4
+strides:
+- 2
+- 2
+padding: SAME
+use_bias: true


### PR DESCRIPTION
Adds the int transpose-conv coverage that would have caught the shipped s8 row-misalignment bug (ns-cmsis-nn#258, fixed by the upstream backport in ns-cmsis-nn#260) before release.

## Change

Three new s8 SAME-padding descriptors in `assets/descriptors/ConvolutionFunctions/transpose_conv.yaml` (the only file touched — zero overlap with #55), each engineered so `pad % stride != 0` on the named axis, the exact condition the bug required:

| case | kernel | stride | pad_h % stride_h | pad_w % stride_w |
|---|---|---|:---:|:---:|
| `..._padrem_h_s8` | 4×6 | 2×2 | **1** | 0 |
| `..._padrem_w_s8` | 6×4 | 2×2 | 0 | **1** |
| `..._padrem_hw_s8` | 4×4 | 2×2 | **1** | **1** (mirrors upstream CMSIS-NN#230's repro shape) |

No s16 variants: the tester maps only S8×S8 for TransposeConv.

## Mutation verification (QEMU mps3-an547, Cortex-M55)

Against ns-cmsis-nn main with the #260 fix reverted (revert diff-verified before building), vs fixed main:

- `padrem_h`: **FAIL (782 mismatches)** on the reverted kernel, PASS on fixed — detects the bug class.
- `padrem_hw`: **FAIL (499)** reverted, PASS fixed — detects the bug class.
- `padrem_w`: PASS on both — **expected**: the shipped bug was vertical-only (`pad_h % stride_h`); the horizontal axis was proven correct in the #260 review. This case is forward-looking coverage for the horizontal analogue.
- All 10 existing-style configs: PASS on both kernels — no false positives.

## Verification

Full pytest: 205 passed; 12 pre-existing failures identical to a pristine `main` baseline — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
