### PR TITLE
fix(abs): follow ns-cmsis-nn's arm_nn_abs_f16/f32 rename

### DIFF
--- a/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
@@ -68,14 +68,14 @@ class OpAbs(OperationBase):
             }
         if activation_dtype == "FP32":
             return {
-                "kernel_fn": "arm_abs_f32",
+                "kernel_fn": "arm_nn_abs_f32",
                 "input_c_type": "float",
                 "output_c_type": "float",
                 "float_kernel": True,
             }
         if activation_dtype == "FP16":
             return {
-                "kernel_fn": "arm_abs_f16",
+                "kernel_fn": "arm_nn_abs_f16",
                 "input_c_type": "float16_t",
                 "output_c_type": "float16_t",
                 "float_kernel": True,

--- a/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
+++ b/helia_core_tester/generation/ops/BasicMathFunctions/abs.py
@@ -111,7 +111,7 @@ class OpAbs(OperationBase):
         activation_dtype = self.desc.get("activation_dtype", "S8")
 
         if kernel_info["float_kernel"]:
-            # arm_abs_f32/f16 are pure (input, output, block_size) kernels
+            # arm_nn_abs_f32/f16 are pure (input, output, block_size) kernels
             # with no quantization or activation parameters.
             float_dtype = np.float16 if kernel_info["input_c_type"] == "float16_t" else np.float32
             rng_state = self.rng.__getstate__()


### PR DESCRIPTION
Companion to AmbiqAI/ns-cmsis-nn#281 — **required before that PR's float codegen jobs can pass**, since the pinned tester emits the old symbol names.

## Why

ns-cmsis-nn's `arm_abs_f16`/`arm_abs_f32` collide by name with CMSIS-DSP functions of the same name and an **incompatible signature**:

| | ns-cmsis-nn | CMSIS-DSP |
|---|---|---|
| return | `arm_cmsis_nn_status` | `void` |
| size param | `int32_t` | `uint32_t` |

Ambiq ships both libraries and applications commonly link both, so link order silently decided which one a consumer got, with no compiler warning (the declarations come from different headers). The float names have never appeared in a published ns-cmsis-nn tag, so they are being renamed now while it is free.

## Change

Two lines in `helia_core_tester/generation/ops/BasicMathFunctions/abs.py` — the FP32 and FP16 `kernel_fn` entries.

`arm_abs_s8` and `arm_abs_s16` are deliberately **unchanged**: they are already shipped, and our integer surface cannot collide with CMSIS-DSP in the first place (we use `_s8`/`_s16`, DSP uses `_q7`/`_q15`/`_q31`).

## Sequencing

Merge here → cut a tester release → bump the submodule pin in ns-cmsis-nn#281. The rename and the pin bump have to land together, since the generated harness calls the symbol by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)